### PR TITLE
Expose flags publicly so that they can be imported

### DIFF
--- a/client/daemon.go
+++ b/client/daemon.go
@@ -3,43 +3,16 @@ package client
 import (
 	"fmt"
 	"github.com/codegangsta/cli"
+	"github.com/rancher/convoy/client/flags"
 	"github.com/rancher/convoy/daemon"
 	"io/ioutil"
 )
 
 var (
 	daemonCmd = cli.Command{
-		Name:  "daemon",
-		Usage: "start convoy daemon",
-		Flags: []cli.Flag{
-			cli.BoolFlag{
-				Name:  "debug",
-				Usage: "Debug log, enabled by default",
-			},
-			cli.StringFlag{
-				Name:  "log",
-				Usage: "specific output log file, otherwise output to stdout by default",
-			},
-			cli.StringFlag{
-				Name:  "root",
-				Value: "/var/lib/convoy",
-				Usage: "specific root directory of convoy, if configure file exists, daemon specific options would be ignored",
-			},
-			cli.StringSliceFlag{
-				Name:  "drivers",
-				Value: &cli.StringSlice{},
-				Usage: "Drivers to be enabled, first driver in the list would be treated as default driver",
-			},
-			cli.StringSliceFlag{
-				Name:  "driver-opts",
-				Value: &cli.StringSlice{},
-				Usage: "options for driver",
-			},
-			cli.StringFlag{
-				Name:  "mnt-ns",
-				Usage: "Specify mount namespace file descriptor if user don't want to mount in current namespace. Support by Device Mapper and EBS",
-			},
-		},
+		Name:   "daemon",
+		Usage:  "start convoy daemon",
+		Flags:  flags.DaemonFlags,
 		Action: cmdStartDaemon,
 	}
 

--- a/client/flags/flags.go
+++ b/client/flags/flags.go
@@ -1,0 +1,37 @@
+package flags
+
+import (
+	"github.com/codegangsta/cli"
+)
+
+var (
+	DaemonFlags = []cli.Flag{
+		cli.BoolFlag{
+			Name:  "debug",
+			Usage: "Debug log, enabled by default",
+		},
+		cli.StringFlag{
+			Name:  "log",
+			Usage: "specific output log file, otherwise output to stdout by default",
+		},
+		cli.StringFlag{
+			Name:  "root",
+			Value: "/var/lib/convoy",
+			Usage: "specific root directory of convoy, if configure file exists, daemon specific options would be ignored",
+		},
+		cli.StringSliceFlag{
+			Name:  "drivers",
+			Value: &cli.StringSlice{},
+			Usage: "Drivers to be enabled, first driver in the list would be treated as default driver",
+		},
+		cli.StringSliceFlag{
+			Name:  "driver-opts",
+			Value: &cli.StringSlice{},
+			Usage: "options for driver",
+		},
+		cli.StringFlag{
+			Name:  "mnt-ns",
+			Usage: "Specify mount namespace file descriptor if user don't want to mount in current namespace. Support by Device Mapper and EBS",
+		},
+	}
+)


### PR DESCRIPTION
This allows convoy-agent to import the flags and expose them as part of
its cli.