### PR TITLE
Change default root to /var/lib/rancher/convoy

### DIFF
--- a/client/flags/flags.go
+++ b/client/flags/flags.go
@@ -16,7 +16,7 @@ var (
 		},
 		cli.StringFlag{
 			Name:  "root",
-			Value: "/var/lib/convoy",
+			Value: "/var/lib/rancher/convoy",
 			Usage: "specific root directory of convoy, if configure file exists, daemon specific options would be ignored",
 		},
 		cli.StringSliceFlag{


### PR DESCRIPTION
Per @ibuildthecloud, we should use the /var/lib/rancher dir on the host. Important for rancherOS.

Disclaimer: I've done no validation of this change. Just made the change and pushed.