### PR TITLE
s3: Determine object size with HEAD; simple and compatible with S3 clones

### DIFF
--- a/s3/s3.go
+++ b/s3/s3.go
@@ -122,17 +122,14 @@ func (s *S3ObjectStoreDriver) FileExists(filePath string) bool {
 
 func (s *S3ObjectStoreDriver) FileSize(filePath string) int64 {
 	path := s.updatePath(filePath)
-	contents, _, err := s.service.ListObjects(path, "/")
+	head, err := s.service.HeadObject(path)
 	if err != nil {
 		return -1
 	}
-
-	if len(contents) == 0 {
+	if head.ContentLength == nil {
 		return -1
 	}
-
-	//TODO deal with multiple returns
-	return *contents[0].Size
+	return *head.ContentLength
 }
 
 func (s *S3ObjectStoreDriver) Remove(names ...string) error {

--- a/s3/s3_service.go
+++ b/s3/s3_service.go
@@ -53,6 +53,23 @@ func (s *S3Service) ListObjects(key, delimiter string) ([]*s3.Object, []*s3.Comm
 	return resp.Contents, resp.CommonPrefixes, nil
 }
 
+func (s *S3Service) HeadObject(key string) (*s3.HeadObjectOutput, error) {
+	svc, err := s.New()
+	if err != nil {
+		return nil, err
+	}
+	defer s.Close()
+	params := &s3.HeadObjectInput{
+		Bucket: aws.String(s.Bucket),
+		Key:    aws.String(key),
+	}
+	resp, err := svc.HeadObject(params)
+	if err != nil {
+		return nil, parseAwsError(resp.String(), err)
+	}
+	return resp, nil
+}
+
 func (s *S3Service) PutObject(key string, reader io.ReadSeeker) error {
 	svc, err := s.New()
 	if err != nil {


### PR DESCRIPTION
`HEAD <obj>` [go-aws-head] determines the object meta data directly,
including object size.  It is simpler than creating a listing with
a single object.  It is also compatible with s3proxy [s3proxy-repo],
which refused to list individual objects.  The same might be true for
other S3 clones.

Compatibility may become important to implement alternative object
storage backends (see GitHub issue #46).

[go-aws-head] <http://docs.aws.amazon.com/sdk-for-go/api/service/s3/S3.html#HeadObject-instance_method>

[s3proxy-repo] <https://github.com/andrewgaul/s3proxy>

Signed-off-by: Steffen Prohaska <prohaska@zib.de>