### PR TITLE
Move vfs config to shared storage dir

### DIFF
--- a/util/index.go
+++ b/util/index.go
@@ -43,9 +43,6 @@ func (idx *Index) Delete(key string) error {
 	idx.lock.Lock()
 	defer idx.lock.Unlock()
 
-	if _, exists := idx.data[key]; !exists {
-		return fmt.Errorf("BUG: About to remove non-existed key %v from index", key)
-	}
 	delete(idx.data, key)
 	return nil
 }

--- a/util/util_test.go
+++ b/util/util_test.go
@@ -227,7 +227,7 @@ func (s *TestSuite) TestIndex(c *C) {
 	c.Assert(err, ErrorMatches, "BUG: Invalid empty index key")
 
 	err = index.Delete("keyx")
-	c.Assert(err, ErrorMatches, "BUG: About to remove non-existed key.*")
+	c.Assert(err, IsNil)
 
 	err = index.Delete("key1")
 	c.Assert(err, IsNil)


### PR DESCRIPTION
This change allows multiple instances of convoy-vfs to use the same config
file. This is necessary for proper orchestration of removing volumes. We
protect against concurrent access to the config file using flock.