### PR TITLE
Add option to create volume during docker mount call

### DIFF
--- a/client/flags/flags.go
+++ b/client/flags/flags.go
@@ -37,5 +37,9 @@ var (
 			Name:  "ignore-docker-delete",
 			Usage: "Do not delete volumes when told to by Docker",
 		},
+		cli.BoolFlag{
+			Name:  "create-on-docker-mount",
+			Usage: "Create a volume if docker asks to do a mount and the volume doesn't exist.",
+		},
 	}
 )

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -45,11 +45,12 @@ var (
 )
 
 type daemonConfig struct {
-	Root               string
-	DriverList         []string
-	DefaultDriver      string
-	MountNamespaceFD   string
-	IgnoreDockerDelete bool
+	Root                string
+	DriverList          []string
+	DefaultDriver       string
+	MountNamespaceFD    string
+	IgnoreDockerDelete  bool
+	CreateOnDockerMount bool
 }
 
 func (c *daemonConfig) ConfigFile() (string, error) {
@@ -292,6 +293,7 @@ func Start(sockFile string, c *cli.Context) error {
 		config.DriverList = driverList
 		config.DefaultDriver = driverList[0]
 		config.IgnoreDockerDelete = c.Bool("ignore-docker-delete")
+		config.CreateOnDockerMount = c.Bool("create-on-docker-mount")
 	}
 
 	s.daemonConfig = *config


### PR DESCRIPTION
This fix works around a bug in docker that prevents you from either
creating or deleting a volume if its been deleted via the convoy api
before being deleted via docker.

The issue arises when you try to recreate a volume that has been
deleted in the above manner. Docker will report it has been created
because it thinks it exists, but the volume will not show up in `docker
volume ls` or `docker volume inspect` and `docker volume rm`s will fail
without ever calling the driver to remvoe the volume.

So this change gives us the ability to create a volume when
docker.mount is called. This will bring the two systems back in sync
and allow the mount to happen.