### PR TITLE
Fix error discarding device when delete volumes

### DIFF
--- a/devmapper/devmapper.go
+++ b/devmapper/devmapper.go
@@ -513,8 +513,12 @@ func (d *Driver) CreateVolume(req Request) error {
 	return nil
 }
 
+func devPath(name string) string {
+	return filepath.Join(DM_DIR, name)
+}
+
 func (d *Driver) removeDevice(name string) error {
-	if err := devicemapper.BlockDeviceDiscard(name); err != nil {
+	if err := devicemapper.BlockDeviceDiscard(devPath(name)); err != nil {
 		log.Debugf("Error %s when discarding %v, ignored", err, name)
 	}
 	for i := 0; i < 200; i++ {


### PR DESCRIPTION
When deleting volumes, convoy daemon will always log error
messages like following:

"Error open volume-e4956a83f67147c0: no such file or directory
 when discarding volume-e4956a83f67147c0, ignored  pkg=devmapper"

This patch fixes it by passing correct argument to the API
devicemapper.BlockDeviceDiscard which expects a full path of
a device instead of just device name.

Signed-off-by: Jin Xu <jinuxstyle@hotmail.com>
Reviewed-by: Sheng Yang <sheng.yang@rancher.com>

V2: use filepath.Join to generate the full path