### PR TITLE
Add options to support xfs and configurable timeout, fix #84, #73, #99

### DIFF
--- a/client/flags/flags.go
+++ b/client/flags/flags.go
@@ -41,5 +41,9 @@ var (
 			Name:  "create-on-docker-mount",
 			Usage: "Create a volume if docker asks to do a mount and the volume doesn't exist.",
 		},
+		cli.StringFlag{
+			Name:  "cmd-timeout",
+			Usage: "Set timeout value for executing each command. One minute (1m) by default and at least one minute.",
+		},
 	}
 )

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -51,6 +51,7 @@ type daemonConfig struct {
 	MountNamespaceFD    string
 	IgnoreDockerDelete  bool
 	CreateOnDockerMount bool
+	CmdTimeout          string
 }
 
 func (c *daemonConfig) ConfigFile() (string, error) {
@@ -294,6 +295,7 @@ func Start(sockFile string, c *cli.Context) error {
 		config.DefaultDriver = driverList[0]
 		config.IgnoreDockerDelete = c.Bool("ignore-docker-delete")
 		config.CreateOnDockerMount = c.Bool("create-on-docker-mount")
+		config.CmdTimeout = c.String("cmd-timeout")
 	}
 
 	s.daemonConfig = *config
@@ -301,6 +303,9 @@ func Start(sockFile string, c *cli.Context) error {
 	if err := util.InitMountNamespace(s.MountNamespaceFD); err != nil {
 		return err
 	}
+
+	util.InitTimeout(config.CmdTimeout)
+
 	// driverOpts would be ignored by Convoy Drivers if config already exists
 	driverOpts := util.SliceToMap(c.StringSlice("driver-opts"))
 	if err := s.initDrivers(driverOpts); err != nil {

--- a/devmapper/devmapper.go
+++ b/devmapper/devmapper.go
@@ -35,6 +35,7 @@ const (
 	DM_THINPOOL_NAME       = "dm.thinpoolname"
 	DM_THINPOOL_BLOCK_SIZE = "dm.thinpoolblocksize"
 	DM_DEFAULT_VOLUME_SIZE = "dm.defaultvolumesize"
+	DM_DEFAULT_FS_TYPE     = "dm.fs"
 
 	// as defined in device mapper thin provisioning
 	BLOCK_SIZE_MIN        = 128
@@ -42,6 +43,7 @@ const (
 	BLOCK_SIZE_MULTIPLIER = 128
 
 	DEFAULT_VOLUME_SIZE = "100G"
+	DEFAULT_FS_TYPE     = "ext4"
 
 	SECTOR_SIZE = 512
 
@@ -115,6 +117,7 @@ type Device struct {
 	ThinpoolBlockSize int64
 	DefaultVolumeSize int64
 	LastDevID         int
+	Filesystem        string
 }
 
 func (dev *Device) ConfigFile() (string, error) {
@@ -186,7 +189,24 @@ func verifyConfig(config map[string]string) (*Device, error) {
 	}
 	dv.DefaultVolumeSize = volumeSize
 
+	if _, exists := config[DM_DEFAULT_FS_TYPE]; !exists {
+		config[DM_DEFAULT_FS_TYPE] = DEFAULT_FS_TYPE
+	}
+	fs_type := config[DM_DEFAULT_FS_TYPE]
+	if !fsSupported(fs_type) {
+		return nil, fmt.Errorf("Unsupported filesystem type specified")
+	}
+	dv.Filesystem = fs_type
+
 	return &dv, nil
+}
+
+func fsSupported(fs_type string) bool {
+	if fs_type == "ext4" || fs_type == "xfs" {
+		return true
+	}
+
+	return false
 }
 
 func (d *Driver) activatePool() error {
@@ -501,7 +521,7 @@ func (d *Driver) CreateVolume(req Request) error {
 	}
 	if backupURL == "" {
 		// format the device
-		if _, err := util.Execute("mkfs", []string{"-t", "ext4", dev}); err != nil {
+		if err := d.createFilesystem(dev); err != nil {
 			return err
 		}
 	} else {
@@ -511,6 +531,22 @@ func (d *Driver) CreateVolume(req Request) error {
 	}
 
 	return nil
+}
+
+func (d *Driver) createFilesystem(dev string) error {
+	var err error
+
+	log.Debugf("Formatting device %s with %s filesystem", dev, d.Filesystem)
+
+	_, err = util.Execute("mkfs", []string{"-t", d.Filesystem, dev})
+
+	if err != nil {
+		log.Errorf("Formatting device failed")
+	} else {
+		log.Debugf("Formatting device done")
+	}
+
+	return err
 }
 
 func devPath(name string) string {

--- a/docs/devicemapper.md
+++ b/docs/devicemapper.md
@@ -16,6 +16,8 @@ __Required__. A small block device called metadata device used to create device 
 ```4096```(2MiB) by default. The block size in 512-byte sectors of thin-provisioning pool. Notice it must be a value between 128 and 2097152, and must be multiples of 128.
 #### ```dm.defaultvolumesize```
 ```100G``` by default. Since we're using thin-provisioning volumes of device mapper, here the volume size is the upper limit of volume size, rather than real volume size allocated on the disk. Though specify a number too big here would result in bigger storage space taken by the empty filesystem.
+#### ```dm.fs```
+```ext4``` by default. Supported filesystem types are ext4 and xfs.
 
 ## Command details
 #### `create`


### PR DESCRIPTION
Two commits: one for supporting xfs with newly added option dm.fs, another for making the timeout value for executing commands configurable.