### PR TITLE
Add option to ignore existing config file #108

### DIFF
--- a/client/flags/flags.go
+++ b/client/flags/flags.go
@@ -45,5 +45,9 @@ var (
 			Name:  "cmd-timeout",
 			Usage: "Set timeout value for executing each command. One minute (1m) by default and at least one minute.",
 		},
+		cli.BoolFlag{
+			Name:  "ignore-config-file",
+			Usage: "Avoid loading the existing config file when starting daemon",
+		},
 	}
 )

--- a/convoydriver/convoydriver.go
+++ b/convoydriver/convoydriver.go
@@ -14,9 +14,10 @@ The registered function would be called upon Convoy need a ConvoyDriver
 instance, and it would return a valid ConvoyDriver for operation.
 
 The registered function would take a "root" path, used as driver's configuration
-file path, and a map of configuration specified for the driver.
+file path, a map of configuration specified for the driver and a option
+for indicating ignoring configure file.
 */
-type InitFunc func(root string, config map[string]string) (ConvoyDriver, error)
+type InitFunc func(root string, config map[string]string, ignoreCfgFile bool) (ConvoyDriver, error)
 
 /*
 ConvoyDriver interface would provide all the functionality needed for driver
@@ -119,10 +120,10 @@ func Register(name string, initFunc InitFunc) error {
 /*
 GetDriver would be called each time when a Convoy Driver instance is needed.
 */
-func GetDriver(name, root string, config map[string]string) (ConvoyDriver, error) {
+func GetDriver(name, root string, config map[string]string, ignoreCfgFile bool) (ConvoyDriver, error) {
 	if _, exists := initializers[name]; !exists {
 		return nil, fmt.Errorf("Driver %v is not supported!", name)
 	}
 	drvRoot := filepath.Join(root, name)
-	return initializers[name](drvRoot, config)
+	return initializers[name](drvRoot, config, ignoreCfgFile)
 }

--- a/devmapper/devmapper.go
+++ b/devmapper/devmapper.go
@@ -294,7 +294,9 @@ func (d *Driver) remountVolumes() error {
 	return err
 }
 
-func Init(root string, config map[string]string) (ConvoyDriver, error) {
+func Init(root string, config map[string]string, ignoreCfgFile bool) (ConvoyDriver, error) {
+	var err error
+
 	devicemapper.LogInitVerbose(1)
 	devicemapper.LogInit(&DMLogger{})
 
@@ -308,10 +310,26 @@ func Init(root string, config map[string]string) (ConvoyDriver, error) {
 	dev := &Device{
 		Root: root,
 	}
-	exists, err := util.ObjectExists(dev)
-	if err != nil {
-		return nil, err
+
+	if ignoreCfgFile {
+		// Ignore configure file only if no volume exists
+		volumeIDs, err := dev.listVolumeNames()
+		if err != nil {
+			return nil, err
+		}
+		if len(volumeIDs) != 0 {
+			ignoreCfgFile = false
+		}
 	}
+
+	exists := false
+	if !ignoreCfgFile {
+		exists, err = util.ObjectExists(dev)
+		if err != nil {
+			return nil, err
+		}
+	}
+
 	if exists {
 		if err := util.ObjectLoad(dev); err != nil {
 			return nil, err

--- a/devmapper/devmapper_test.go
+++ b/devmapper/devmapper_test.go
@@ -132,23 +132,23 @@ func (s *TestSuite) TearDownSuite(c *C) {
 func (s *TestSuite) initDriver(c *C) {
 	config := make(map[string]string)
 
-	_, err := Init(devCfgRoot, config)
+	_, err := Init(devCfgRoot, config, false)
 	c.Assert(err, ErrorMatches, "data device or metadata device unspecified")
 
 	config[DM_DATA_DEV] = s.dataDev
 	config[DM_METADATA_DEV] = s.metadataDev
 	config[DM_THINPOOL_BLOCK_SIZE] = "100"
-	_, err = Init(devCfgRoot, config)
+	_, err = Init(devCfgRoot, config, false)
 	c.Assert(err, Not(IsNil))
 	c.Assert(err, ErrorMatches, "Block size must.*")
 
 	config[DM_THINPOOL_NAME] = "test_pool"
 	delete(config, DM_THINPOOL_BLOCK_SIZE)
 
-	driver, err := Init(devCfgRoot, config)
+	driver, err := Init(devCfgRoot, config, false)
 	c.Assert(err, IsNil)
 
-	newDriver, err := Init(devCfgRoot, config)
+	newDriver, err := Init(devCfgRoot, config, false)
 	c.Assert(err, IsNil)
 
 	drv1, ok := driver.(*Driver)

--- a/ebs/ebs.go
+++ b/ebs/ebs.go
@@ -143,7 +143,7 @@ func (d *Driver) remountVolumes() error {
 	return err
 }
 
-func Init(root string, config map[string]string) (ConvoyDriver, error) {
+func Init(root string, config map[string]string, ignoreCfgFile bool) (ConvoyDriver, error) {
 	ebsService, err := NewEBSService()
 	if err != nil {
 		return nil, err
@@ -151,10 +151,26 @@ func Init(root string, config map[string]string) (ConvoyDriver, error) {
 	dev := &Device{
 		Root: root,
 	}
-	exists, err := util.ObjectExists(dev)
-	if err != nil {
-		return nil, err
+
+	if ignoreCfgFile {
+		// Ignore configure file only if no volume exists
+		volumeIDs, err := dev.listVolumeNames()
+		if err != nil {
+			return nil, err
+		}
+		if len(volumeIDs) != 0 {
+			ignoreCfgFile = false
+		}
 	}
+
+	exists := false
+	if !ignoreCfgFile {
+		exists, err = util.ObjectExists(dev)
+		if err != nil {
+			return nil, err
+		}
+	}
+
 	if exists {
 		if err := util.ObjectLoad(dev); err != nil {
 			return nil, err
@@ -500,8 +516,8 @@ func (d *Driver) GetVolumeInfo(id string) (map[string]string, error) {
 	return info, nil
 }
 
-func (d *Driver) listVolumeNames() ([]string, error) {
-	return util.ListConfigIDs(d.Root, CFG_PREFIX+VOLUME_CFG_PREFIX, CFG_POSTFIX)
+func (dev *Device) listVolumeNames() ([]string, error) {
+	return util.ListConfigIDs(dev.Root, CFG_PREFIX+VOLUME_CFG_PREFIX, CFG_POSTFIX)
 }
 func (d *Driver) ListVolume(opts map[string]string) (map[string]map[string]string, error) {
 	volumes := make(map[string]map[string]string)

--- a/longhorn/longhorn.go
+++ b/longhorn/longhorn.go
@@ -143,14 +143,32 @@ func override(existing, newValue string) string {
 	return existing
 }
 
-func Init(root string, config map[string]string) (ConvoyDriver, error) {
+func Init(root string, config map[string]string, ignoreCfgFile bool) (ConvoyDriver, error) {
+	var err error
+
 	dev := &Device{
 		Root: root,
 	}
-	exists, err := util.ObjectExists(dev)
-	if err != nil {
-		return nil, err
+
+	if ignoreCfgFile {
+		// Ignore configure file only if no volume exists
+		volumeIDs, err := dev.listVolumeIDs()
+		if err != nil {
+			return nil, err
+		}
+		if len(volumeIDs) != 0 {
+			ignoreCfgFile = false
+		}
 	}
+
+	exists := false
+	if !ignoreCfgFile {
+		exists, err = util.ObjectExists(dev)
+		if err != nil {
+			return nil, err
+		}
+	}
+
 	if exists {
 		if err := util.ObjectLoad(dev); err != nil {
 			return nil, err

--- a/vfs/vfs_storage.go
+++ b/vfs/vfs_storage.go
@@ -86,14 +86,32 @@ func (device *Device) listVolumeNames() ([]string, error) {
 	return util.ListConfigIDs(device.ConfigPath, VFS_CFG_PREFIX+VOLUME_CFG_PREFIX, CFG_POSTFIX)
 }
 
-func Init(root string, config map[string]string) (ConvoyDriver, error) {
+func Init(root string, config map[string]string, ignoreCfgFile bool) (ConvoyDriver, error) {
+	var err error
+
 	dev := &Device{
 		Root: root,
 	}
-	exists, err := util.ObjectExists(dev)
-	if err != nil {
-		return nil, err
+
+	if ignoreCfgFile {
+		// Ignore configure file only if no volume exists
+		volumeIDs, err := dev.listVolumeNames()
+		if err != nil {
+			return nil, err
+		}
+		if len(volumeIDs) != 0 {
+			ignoreCfgFile = false
+		}
 	}
+
+	exists := false
+	if !ignoreCfgFile {
+		exists, err = util.ObjectExists(dev)
+		if err != nil {
+			return nil, err
+		}
+	}
+
 	if exists {
 		if err := util.ObjectLoad(dev); err != nil {
 			return nil, err


### PR DESCRIPTION
Convoy daemon saves command line options to configure files for the
first run. Later on when user starts the daemon again with different
command line options, it will always load the configure files and
use the previously saved command lines options instead of using the
new options. The only way out is deleting the config file manually or
specifing a different directory for --root option.

This patch adds a new option --ignore-config-file to fix the problem.
When this option is given, convoy daemon will ignore the general
configure file and ignore the driver specific configure file only if
there is no existing volume under the driver.

Signed-off-by: Jin Xu <jinuxstyle@hotmail.com>