### PR TITLE
Add option to ignore existing config file #108

### DIFF
--- a/client/flags/flags.go
+++ b/client/flags/flags.go
@@ -45,5 +45,9 @@ var (
 			Name:  "cmd-timeout",
 			Usage: "Set timeout value for executing each command. One minute (1m) by default and at least one minute.",
 		},
+		cli.BoolFlag{
+			Name:  "ignore-config-file",
+			Usage: "Avoid loading the existing config file when starting daemon, and use the command line options instead (not including driver options)",
+		},
 	}
 )

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -267,10 +267,16 @@ func Start(sockFile string, c *cli.Context) error {
 	config := &daemonConfig{
 		Root: root,
 	}
-	exists, err := util.ObjectExists(config)
-	if err != nil {
-		return err
+
+	ignoreCfgFile := c.Bool("ignore-config-file")
+	exists := false
+	if !ignoreCfgFile {
+		exists, err = util.ObjectExists(config)
+		if err != nil {
+			return err
+		}
 	}
+
 	if exists {
 		log.Debug("Found existing config. Ignoring command line opts, loading config from ", root)
 		if err := util.ObjectLoad(config); err != nil {


### PR DESCRIPTION
When the config file exists, convoy daemon always loads it and ignore
user's command line options. The only way out is deleting the config
file manually. This is not user friendly if user would like to start
the daemon with different options from the originally saved. So a
new option --ignore-config-file is added to avoid using the existing
config file. Note that this option has no effect on driver options.
Even with this option given, each driver will still use their own
existing config file and ignore command line driver options.

Signed-off-by: Jin Xu <jinuxstyle@hotmail.com>
Reviewed-by: Sheng Yang <sheng.yang@rancher.com>