### PR TITLE
Fix readme typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ sudo cp convoy/convoy convoy/convoy-pdata_tools /usr/local/bin/
 sudo mkdir -p /etc/docker/plugins/
 sudo bash -c 'echo "unix:///var/run/convoy/convoy.sock" > /etc/docker/plugins/convoy.spec'
 ```
-We can use file-backed lookback device to test and demo Convoy Device Mapper driver. Loopback device, however, is known to be unstable and should not be used in production.
+We can use file-backed loopback device to test and demo Convoy Device Mapper driver. Loopback device, however, is known to be unstable and should not be used in production.
 ```
 truncate -s 100G data.vol
 truncate -s 1G metadata.vol


### PR DESCRIPTION
It should be `loopback` instead of `lookback` in README.md, I think it is a typo. 