### PR TITLE
convoy list options "--driver" should return the volumes for the specific driver

### DIFF
--- a/client/volume.go
+++ b/client/volume.go
@@ -80,7 +80,7 @@ var (
 		Name:  "list",
 		Usage: "list all managed volumes",
 		Flags: []cli.Flag{
-			cli.BoolFlag{
+			cli.StringFlag{
 				Name:  "driver",
 				Usage: "Ask for driver specific info of volumes and snapshots",
 			},
@@ -182,9 +182,15 @@ func cmdVolumeList(c *cli.Context) {
 
 func doVolumeList(c *cli.Context) error {
 	v := url.Values{}
-	if c.Bool("driver") {
-		v.Set("driver", "1")
-	}
+
+        var err error
+        driver, err := util.GetFlag(c, "driver", false, err)
+        if err != nil {
+            return err
+        }
+        if driver != "" {
+            v.Set("driver", driver)
+        }
 
 	url := "/volumes/list?" + v.Encode()
 	return sendRequestAndPrint("GET", url, nil)

--- a/daemon/volume.go
+++ b/daemon/volume.go
@@ -315,9 +315,15 @@ func (s *daemon) doVolumeList(version string, w http.ResponseWriter, r *http.Req
 	}
 
 	var data []byte
-	if driverSpecific == "1" {
+	if driverSpecific != "" {
+                driverResult := make(map[string]map[string]string)
 		result := s.getVolumeList()
-		data, err = api.ResponseOutput(&result)
+                for k, v := range result {
+                    if v["Driver"] == driverSpecific {
+                        driverResult[k] = v
+                    }
+                }  
+		data, err = api.ResponseOutput(&driverResult)
 	} else {
 		data, err = s.listVolume()
 	}


### PR DESCRIPTION
@yasker

i guess the options --driver means return the volumes for the specific driver ,like:
convoy list --driver devicemapper
return all volumes of devicemapper driver  
or
convoy list --driver vfs
return all volumes of vfs driver

please review. thanks