### PR TITLE
adding convoy change for k8s client

### DIFF
--- a/api/request.go
+++ b/api/request.go
@@ -3,6 +3,9 @@ package api
 type VolumeMountRequest struct {
 	VolumeName string
 	MountPoint string
+	ReadWrite  string // either "rw or "ro"
+	BindMount  string // either "bind" or "rbind"
+	ReMount    bool   // allow or disallow mount with a new mountpoint
 	Verbose    bool
 }
 
@@ -19,6 +22,7 @@ type VolumeCreateRequest struct {
 	Type           string
 	IOPS           int64
 	PrepareForVM   bool
+	FSType         string
 	Verbose        bool
 }
 

--- a/client/k8s.go
+++ b/client/k8s.go
@@ -350,11 +350,6 @@ func doMount(c *cli.Context) error {
 	}
 
 	request := &api.VolumeMountRequest{}
-
-	// k8s needs driver to create mountpoint directory, but k8s will delete it when unmount
-	if err := util.CallMkdirIfNotExists(mountpoint); err != nil {
-		return err
-	}
 	request.MountPoint = mountpoint
 	request.ReadWrite = optionsMap["kubernetes.io/readwrite"]
 	log.Debugf("kubernetes.io/readwrite: %s", request.ReadWrite)

--- a/client/k8s.go
+++ b/client/k8s.go
@@ -1,0 +1,437 @@
+package client
+
+import (
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"net/url"
+	"reflect"
+	"strings"
+
+	"github.com/codegangsta/cli"
+	"github.com/rancher/convoy/api"
+	"github.com/rancher/convoy/util"
+)
+
+var (
+	initCmd = cli.Command{
+		Name:   "init",
+		Usage:  "ensure convoy daemon exist",
+		Action: cmdCheckConvoyDaemon,
+	}
+
+	volumeAttachCmd = cli.Command{
+		Name:   "attach",
+		Usage:  "attach a volume: attach <json-options>",
+		Action: cmdAttachVolume,
+	}
+
+	volumeDetachCmd = cli.Command{
+		Name:   "detach",
+		Usage:  "detach a volume: detach <device>",
+		Action: cmdDetachVolume,
+	}
+
+	mountCmd = cli.Command{
+		Name:   "mount",
+		Usage:  "mount a volume: mount <mountpoint> <device> <json-options>",
+		Action: cmdMount,
+	}
+
+	unmountCmd = cli.Command{
+		Name:   "unmount",
+		Usage:  "unmount a volume: unmount <mountpoint>",
+		Action: cmdUnmount,
+	}
+)
+
+func NewK8sCli(version string) *cli.App {
+	app := cli.NewApp()
+	app.Name = "k8s"
+	app.Version = version
+	app.Author = "rancherlabs"
+	app.Usage = "A kubernetes volume driver"
+	app.Flags = []cli.Flag{
+		cli.StringFlag{
+			Name:  "socket, s",
+			Value: "/var/run/convoy/convoy.sock",
+			Usage: "Specify unix domain socket for communication between server and client",
+		},
+		cli.BoolFlag{
+			Name:  "debug, d",
+			Usage: "Enable debug level log with client or not",
+		},
+		cli.BoolFlag{
+			Name:  "verbose",
+			Usage: "Verbose level output for client, for create volume/snapshot etc",
+		},
+	}
+	app.CommandNotFound = cmdNotFound
+	app.Before = initClient
+	app.Commands = []cli.Command{
+		initCmd,
+		volumeAttachCmd,
+		volumeDetachCmd,
+		mountCmd,
+		unmountCmd,
+	}
+	return app
+}
+
+func cmdCheckConvoyDaemon(c *cli.Context) {
+	// ensure daemon is running
+	if _, _, err := client.call("GET", "/info", nil, nil); err != nil {
+		fmt.Print("{\"status\": \"Failure\"}")
+		panic(err)
+	}
+	fmt.Print("{\"status\": \"Success\"}")
+}
+
+func cmdAttachVolume(c *cli.Context) {
+	if err := doAttachVolume(c); err != nil {
+		fmt.Print("{\"status\": \"Failure\"}")
+		panic(err)
+	}
+}
+
+func doAttachVolume(c *cli.Context) error {
+	var err error
+
+	jsonOptions := c.Args().First()
+	log.Debugf("jsonOptions: %s", jsonOptions)
+
+	// parse json options:
+	//
+	// driver:      driver name, such as NFS, EBS, EFS.
+	// readOnly:    the volume mounted as readOnly
+	// fsType:      the volume formated as this file system type, if volume is created new
+	//
+	// Following parameters are for EBS:
+	// volumeId:    existing EBS volume id
+	// size:  		create a new volume using this size
+	// volumeType:  create a new volume using this volume type
+	// iops:		create a new volume using this iops
+	//
+	// Following parameters are for NFS or EFS:
+	// name:		folder name or volume name in Convoy VFS driver
+
+	optionsMap := make(map[string]string)
+	err = json.Unmarshal([]byte(jsonOptions), &optionsMap)
+	if err != nil {
+		return err
+	}
+	log.Debugf("optionsMap: %v", optionsMap)
+
+	driverName, ok := optionsMap["convoyDriver"]
+	if !ok {
+		return fmt.Errorf("no convoyDriver option specified")
+	}
+	request := &api.VolumeCreateRequest{}
+
+	switch driverName {
+	case "ebs":
+		request.DriverName = driverName
+		return doAttachEBSVolume(request, optionsMap)
+	case "efs":
+		fallthrough
+	case "nfs":
+		request.DriverName = "vfs"
+		return doCreateVFSVolume(request, optionsMap)
+	default:
+		return fmt.Errorf("unrecognized convoyDriver name specified")
+	}
+}
+
+func doAttachEBSVolume(request *api.VolumeCreateRequest, optionsMap map[string]string) error {
+	request.DriverVolumeID = optionsMap["volumeID"]
+	request.Type = optionsMap["volumeType"]
+
+	size, err := util.ParseSize(optionsMap["size"])
+	if err != nil {
+		return err
+	}
+	request.Size = size
+	iops, err := util.ParseSize(optionsMap["iops"])
+	if err != nil {
+		return err
+	}
+	request.IOPS = iops
+	request.Verbose = true // need attached device name from the response
+	request.FSType = optionsMap["kubernetes.io/fsType"]
+
+	url := "/volumes/create"
+	rc, err := sendRequest("POST", url, request)
+	if err != nil {
+		return err
+	}
+	defer rc.Close()
+
+	b, err := ioutil.ReadAll(rc)
+	if err != nil {
+		return err
+	}
+	log.Debugf("response: %s\n", string(b))
+	var vol api.VolumeResponse
+	err = json.Unmarshal(b, &vol)
+	if err != nil {
+		return err
+	}
+	device := vol.DriverInfo["Device"]
+	fmt.Printf("{\"status\": \"Success\", \"device\":\"%s\"}", device)
+
+	return nil
+}
+
+func cmdDetachVolume(c *cli.Context) {
+	device := c.Args().First()
+	log.Debugf("device: %s", device)
+
+	if err := doVolumeDetach(device); err != nil {
+		fmt.Print("{\"status\": \"Failure\"}")
+		panic(err)
+	}
+	fmt.Print("{\"status\": \"Success\"}")
+}
+
+func doVolumeDetach(device string) error {
+	var vol *api.VolumeResponse
+	var err error
+
+	if strings.HasPrefix(device, "/dev") { // block device
+		vol, err = getVolumeByProperty("Device", device)
+		if err != nil {
+			return err
+		}
+	} else if strings.ContainsAny(device, ":") { // networked FS, such as NFS
+		lastSlashIndex := strings.LastIndex(device, "/")
+		name := device[lastSlashIndex+1:]
+		vol, err = getVolumeByProperty("VolumeName", name)
+		if err != nil {
+			return err
+		}
+	}
+
+	switch vol.Driver {
+	case "vfs":
+		fallthrough
+	case "ebs":
+		request := &api.VolumeDeleteRequest{
+			VolumeName: vol.Name,
+		}
+
+		url := "/volumes/"
+		_, err := sendRequest("DELETE", url, request)
+		if err != nil {
+			return fmt.Errorf("Error deleting " + vol.Name + ": " + err.Error())
+		}
+		return nil
+	default:
+		return nil
+	}
+}
+
+func getVolumeByProperty(key string, value string) (*api.VolumeResponse, error) {
+	vol, err := findVolumeByProperty(key, value)
+	if err != nil {
+		return nil, err
+	}
+	if vol == nil {
+		return nil, fmt.Errorf("can't find volume by DriverInfo property: key=%s, value=%s", key, value)
+	}
+
+	return vol, nil
+}
+
+func findVolumeByProperty(key string, value string) (*api.VolumeResponse, error) {
+	v := url.Values{}
+	url := "/volumes/list?" + v.Encode()
+	rc, err := sendRequest("GET", url, nil)
+	if err != nil {
+		return nil, err
+	}
+	defer rc.Close()
+
+	b, err := ioutil.ReadAll(rc)
+	if err != nil {
+		return nil, err
+	}
+	resp := make(map[string]api.VolumeResponse)
+	log.Debugf("volume list response: %s\n", string(b))
+	err = json.Unmarshal(b, &resp)
+	if err != nil {
+		return nil, err
+	}
+
+	// loop through and find the volume
+	var volume api.VolumeResponse
+	for _, vol := range resp {
+		propertyValue, ok := vol.DriverInfo[key]
+		if !ok {
+			continue
+		}
+		if propertyValue == value {
+			volume = vol
+			break
+		}
+	}
+	if reflect.DeepEqual(volume, api.VolumeResponse{}) {
+		return nil, nil
+	}
+
+	return &volume, nil
+}
+
+func doCreateVFSVolume(request *api.VolumeCreateRequest, optionsMap map[string]string) error {
+	name, ok := optionsMap["name"]
+	if !ok {
+		return fmt.Errorf("no name option specified")
+	}
+
+	// check if the volume exists or not. If exists, then do nothing
+	vol, err := findVolumeByProperty("VolumeName", name)
+	if err != nil {
+		return err
+	}
+	if vol == nil {
+		request.Name = name
+
+		url := "/volumes/create"
+		_, err := sendRequest("POST", url, request)
+		if err != nil {
+			return err
+		}
+	}
+	fmt.Printf("{\"status\": \"Success\"}")
+
+	return nil
+}
+
+func cmdMount(c *cli.Context) {
+	if err := doMount(c); err != nil {
+		fmt.Print("{\"status\": \"Failure\"}")
+		panic(err)
+	}
+	fmt.Print("{\"status\": \"Success\"}")
+}
+
+func doMount(c *cli.Context) error {
+	var err error
+	mountpoint := c.Args().First()
+	tail := c.Args().Tail()
+	jsonOptions := tail[len(tail)-1]
+
+	log.Debugf("mountpoint: %s, jsonOptions: %s", mountpoint, jsonOptions)
+
+	// parse json options:
+	//
+	// driver:      driver name, such as NFS, EBS, EFS.
+	// readOnly:    the volume mounted as readOnly
+	// fsType:      the volume formated as this file system type, if volume is created new
+	//
+	// Following parameters are for EBS:
+	// volumeId:    existing EBS volume id
+	// size:  		create a new volume using this size
+	// volumeType:  create a new volume using this volume type
+	// iops:		create a new volume using this iops
+	//
+	// Following parameters are for NFS or EFS:
+	// name:		folder name or volume name in Convoy VFS driver
+
+	optionsMap := make(map[string]string)
+	err = json.Unmarshal([]byte(jsonOptions), &optionsMap)
+	if err != nil {
+		return err
+	}
+	log.Debugf("optionsMap: %v", optionsMap)
+
+	driverName, ok := optionsMap["convoyDriver"]
+	if !ok {
+		return fmt.Errorf("no convoyDriver option specified")
+	}
+
+	request := &api.VolumeMountRequest{}
+
+	// k8s needs driver to create mountpoint directory, but k8s will delete it when unmount
+	if err := util.CallMkdirIfNotExists(mountpoint); err != nil {
+		return err
+	}
+	request.MountPoint = mountpoint
+	request.ReadWrite = optionsMap["kubernetes.io/readwrite"]
+	log.Debugf("kubernetes.io/readwrite: %s", request.ReadWrite)
+
+	if request.ReadWrite != "rw" && request.ReadWrite != "ro" {
+		return fmt.Errorf("kubernetes.io/readwrite is not rw or ro")
+	}
+	switch driverName {
+	case "ebs":
+		device := c.Args().Get(1)
+		log.Debugf("device: %s", device)
+		return doMountEBS(request, device, optionsMap)
+	case "efs":
+		fallthrough
+	case "nfs":
+		return doMountVFS(request, optionsMap)
+	default:
+		return fmt.Errorf("unrecognized convoyDriver name specified")
+	}
+}
+
+func doMountEBS(request *api.VolumeMountRequest, device string, optionsMap map[string]string) error {
+	vol, err := getVolumeByProperty("Device", device)
+	if err != nil {
+		return err
+	}
+	request.VolumeName = vol.Name
+
+	url := "/volumes/mount"
+	_, err = sendRequest("POST", url, request)
+	if err != nil {
+		return fmt.Errorf("Error mounting device: %s to mountpoint: %s, err: %s", device, request.MountPoint, err)
+	}
+
+	return nil
+}
+
+func doMountVFS(request *api.VolumeMountRequest, optionsMap map[string]string) error {
+	name, ok := optionsMap["name"]
+	if !ok {
+		return fmt.Errorf("no name option specified")
+	}
+	request.VolumeName = name
+	request.BindMount = "rbind"
+	request.ReMount = true
+
+	url := "/volumes/mount"
+	if _, err := sendRequest("POST", url, request); err != nil {
+		return fmt.Errorf("Error bind mounting: %s to mountpoint: %s, err: %s", name, request.MountPoint, err)
+	}
+
+	return nil
+}
+
+func cmdUnmount(c *cli.Context) {
+	if err := doUnmount(c); err != nil {
+		fmt.Print("{\"status\": \"Failure\"}")
+		panic(err)
+	}
+	fmt.Print("{\"status\": \"Success\"}")
+}
+
+func doUnmount(c *cli.Context) error {
+	mountpoint := c.Args().First()
+	vol, err := getVolumeByProperty("MountPoint", mountpoint)
+	if err != nil {
+		return err
+	}
+
+	request := &api.VolumeUmountRequest{
+		VolumeName: vol.Name,
+	}
+	url := "/volumes/umount"
+	_, err = sendRequest("POST", url, request)
+	if err != nil {
+		return fmt.Errorf("Error unmounting mountpoint: %s, err: %s", mountpoint, err)
+	}
+
+	return nil
+}

--- a/convoydriver/convoydriver.go
+++ b/convoydriver/convoydriver.go
@@ -96,6 +96,9 @@ const (
 	OPT_REFERENCE_ONLY        = "ReferenceOnly"
 	OPT_PREPARE_FOR_VM        = "PrepareForVM"
 	OPT_FILESYSTEM            = "Filesystem"
+	OPT_READ_WRITE            = "ReadWrite"
+	OPT_BIND_MOUNT            = "BindMount"
+	OPT_REMOUNT               = "ReMount"
 )
 
 var (

--- a/daemon/volume.go
+++ b/daemon/volume.go
@@ -113,6 +113,7 @@ func (s *daemon) processVolumeCreate(request *api.VolumeCreateRequest) (*Volume,
 			OPT_VOLUME_TYPE:      request.Type,
 			OPT_VOLUME_IOPS:      strconv.FormatInt(request.IOPS, 10),
 			OPT_PREPARE_FOR_VM:   strconv.FormatBool(request.PrepareForVM),
+			OPT_FILESYSTEM:       request.FSType,
 		},
 	}
 	log.WithFields(logrus.Fields{
@@ -395,11 +396,18 @@ func (s *daemon) processVolumeMount(volume *Volume, request *api.VolumeMountRequ
 	if err != nil {
 		return "", err
 	}
+	remount := ""
+	if request.ReMount {
+		remount = OPT_REMOUNT
+	}
 
 	req := Request{
 		Name: volume.Name,
 		Options: map[string]string{
 			OPT_MOUNT_POINT: request.MountPoint,
+			OPT_READ_WRITE:  request.ReadWrite,
+			OPT_BIND_MOUNT:  request.BindMount,
+			OPT_REMOUNT:     remount,
 		},
 	}
 	log.WithFields(logrus.Fields{

--- a/docs/kubernetes.md
+++ b/docs/kubernetes.md
@@ -1,0 +1,104 @@
+# Using Kubernetes Flex Volume Plugin
+
+As a Kubernetes flex volume plugin, k8s driver binary works with Convoy daemon to provide volume management tasks for uses using Kubenetes.
+
+## Register Flex Volume plugin to Kubernetes
+
+Please make sure Kubernetes v1.3.4+ are installed. Create a folder(vendor~driver) on the Kubelet volume plugin path: /usr/libexec/kubernetes/kubelet-plugins/volume/exec
+```
+sudo mkdir -p /usr/libexec/kubernetes/kubelet-plugins/volume/exec/rancher.io~k8s
+```
+Here we have a driver called k8s and vendor name is rancher.io. Then copy k8s driver binary to above created folder
+```
+sudo cp k8s /usr/libexec/kubernetes/kubelet-plugins/volume/exec/rancher.io~k8s
+```
+
+## Initialization
+
+When Kubelet starts, it will call all the volume plugin drivers in the folder /usr/libexec/kubernetes/kubelet-plugins/volume/exec
+with "init" cmd as the argument to the binary(k8s) to let the drivers initialize themselves
+
+## Flex Volume plugin integration with Kubelet
+
+When Kubernetes deploys a pod on the node, Kubelet will find the volume plugin driver according to pod spec in Kubelet volume plugin path, then Kubelet
+will invoke the plugin drivers several times with different tasks to eventually mount a persistent volume for docker container to use inside the container.
+
+Kubelet invokes volume plugin driver with 4 main commands: Attach, Detach, Mount, Unmount, besides Init
+
+### Here is Flex Volume driver invocation model by Kubenetes:
+
+Init:
+```
+driver  init
+```
+
+Attach:
+```
+driver  attach json_options
+``` 
+
+Detach:
+```
+driver  detach  mounted_device
+```
+
+Mount:
+```
+driver  mount  mountpoint optional_mounted_device json_options
+``` 
+Unmount:
+```
+driver  unmount  mountpoint
+```
+
+The json_options are the options in the pod spec under Flex Volume section, to pass vendor driver's specific options
+
+### Driver output:
+
+Flex Volume expects the driver to reply with the status of each invocation in the following format.
+
+```
+{
+    "status": "Success/Failure"
+    "message": "Reason for success/failure"
+    "device": "Path to the device attached. This field is valid only for attach calls. Also it is optional."
+}
+```
+
+### Rancher Flex Volume Spec options -- json_options
+
+Rancher Flex Volume driver supports different options according to different Convoy drivers loaded in the Convoy daemon.
+The first options is
+
+```
+"convoyDriver" : "ebs/nfs/efs",   which Convoy daemon driver to use to manage the volumes
+```
+
+#### if convoyDriver = ebs
+
+User is responsible to setup aws ec2 access to instances and ebs volumes on the Kubelet host before using the driver
+
+```
+ "volumeId" : "existing EBS volume id"
+ "volumeType" : "create a new volume using this EBS volume type"
+ "size" : "create a new volume using this size"
+ "iops" : "create a new volume using this iops"
+```
+
+#### if convoyDriver = nfs or convoyDriver = efs
+
+User is responsible to mount a remote file system to a path(localPath) and invoke Convoy with vfs.Path=localPath specified
+
+```
+ "name" : "Convoy volume name, actually a folder name representing the NFS/EFS volume'
+```
+
+#### Kubenetes built in options
+
+In addition to the flags specified by the user in the Options, the following flags are also passed to the executable, that
+Rancher's k8s driver will make use.
+
+```
+"kubernetes.io/fsType" : "FS type"
+"kubernetes.io/readwrite" : "rw/ro"
+```

--- a/ebs/ebs.go
+++ b/ebs/ebs.go
@@ -30,6 +30,7 @@ const (
 
 	DEFAULT_VOLUME_SIZE = "4G"
 	DEFAULT_VOLUME_TYPE = "gp2"
+	DEFAULT_FILE_SYSTEM = "ext4"
 
 	MOUNTS_DIR    = "mounts"
 	MOUNT_BINARY  = "mount"
@@ -69,6 +70,8 @@ type Volume struct {
 	Snapshots  map[string]Snapshot
 
 	configPath string
+	PreExist   bool
+	ReadWrite  string
 }
 
 func (d *Driver) blankVolume(name string) *Volume {
@@ -93,7 +96,11 @@ func (v *Volume) GetDevice() (string, error) {
 }
 
 func (v *Volume) GetMountOpts() []string {
-	return []string{}
+	options := []string{}
+	if v.ReadWrite != "" {
+		options = append(options, "-o", v.ReadWrite)
+	}
+	return options
 }
 
 func (v *Volume) GenerateDefaultMountPoint() string {
@@ -295,6 +302,7 @@ func (d *Driver) CreateVolume(req Request) error {
 		if err := d.ebsService.AddTags(volumeID, newTags); err != nil {
 			log.Debugf("Failed to update tags for volume %v, but continue", volumeID)
 		}
+		volume.PreExist = true
 
 		// detach from all instances
 		for _, attachment := range ebsVolume.Attachments {
@@ -391,11 +399,14 @@ func (d *Driver) CreateVolume(req Request) error {
 
 	// We don't format existing or snapshot restored volume
 	if format {
-		if _, err := util.Execute("mkfs", []string{"-t", "ext4", dev}); err != nil {
+		fileSystem := DEFAULT_FILE_SYSTEM
+		if opts[OPT_FILESYSTEM] != "" {
+			fileSystem = opts[OPT_FILESYSTEM]
+		}
+		if _, err := util.Execute("mkfs", []string{"-t", fileSystem, dev}); err != nil {
 			return err
 		}
 	}
-
 	return util.ObjectSave(volume)
 }
 
@@ -423,7 +434,7 @@ func (d *Driver) DeleteVolume(req Request) error {
 		log.Debugf("Detached %v(%v) from %v", id, volume.EBSID, volume.Device)
 	}
 
-	if !referenceOnly {
+	if !referenceOnly && !volume.PreExist {
 		if err := d.ebsService.DeleteVolume(volume.EBSID); err != nil {
 			return err
 		}
@@ -440,7 +451,7 @@ func (d *Driver) MountVolume(req Request) (string, error) {
 	if err := util.ObjectLoad(volume); err != nil {
 		return "", err
 	}
-
+	volume.ReadWrite = opts[OPT_READ_WRITE]
 	mountPoint, err := util.VolumeMount(volume, opts[OPT_MOUNT_POINT], false)
 	if err != nil {
 		return "", err

--- a/ebs/ebs.go
+++ b/ebs/ebs.go
@@ -312,7 +312,7 @@ func (d *Driver) CreateVolume(req Request) error {
 				return err
 			}
 			if running {
-				return fmt.Errorf("can't detach ebs volumeID: %s from instanceID: %s, instance is running", *ebsVolume.VolumeId, *attachment.InstanceId)
+				return fmt.Errorf("can't re-use ebs volumeID: %s from instanceID: %s, instance is running", *ebsVolume.VolumeId, *attachment.InstanceId)
 			}
 			log.Debugf("detaching ebs volumeID: %s from instanceID: %s ...", *ebsVolume.VolumeId, *attachment.InstanceId)
 			d.ebsService.DetachVolumeFromInstance(ebsVolume.VolumeId, attachment.InstanceId)

--- a/ebs/ebs_service.go
+++ b/ebs/ebs_service.go
@@ -250,6 +250,11 @@ func (s *ebsService) IsInstanceRunning(instanceID *string) (bool, error) {
 	}
 	instanceStatus, err := s.ec2Client.DescribeInstanceStatus(params)
 	if err != nil {
+		if awsErr, ok := err.(awserr.Error); ok {
+			if awsErr.Code() == "InvalidInstanceID.NotFound" {
+				return false, nil
+			}
+		}
 		return false, parseAwsError(err)
 	}
 	if len(instanceStatus.InstanceStatuses) != 1 {

--- a/ebs/ebs_service.go
+++ b/ebs/ebs_service.go
@@ -145,7 +145,7 @@ func (s *ebsService) waitForVolumeAttaching(volumeID string) error {
 		if len(volume.Attachments) != 0 {
 			attachment = volume.Attachments[0]
 		} else {
-			return fmt.Errorf("Attaching failed for ", volumeID)
+			return fmt.Errorf("Attaching failed for %s", volumeID)
 		}
 	}
 	if *attachment.State != ec2.VolumeAttachmentStateAttached {
@@ -191,7 +191,6 @@ func (s *ebsService) CreateVolume(request *CreateEBSVolumeRequest) (string, erro
 			params.Iops = aws.Int64(iops)
 		}
 	}
-
 	ec2Volume, err := s.ec2Client.CreateVolume(params)
 	if err != nil {
 		return "", parseAwsError(err)
@@ -239,6 +238,24 @@ func (s *ebsService) GetVolume(volumeID string) (*ec2.Volume, error) {
 		return nil, fmt.Errorf("Cannot find volume %v", volumeID)
 	}
 	return volumes.Volumes[0], nil
+}
+
+func (s *ebsService) IsInstanceRunning(instanceID *string) (bool, error) {
+	includeAll := true
+	params := &ec2.DescribeInstanceStatusInput{
+		InstanceIds: []*string{
+			instanceID,
+		},
+		IncludeAllInstances: &includeAll,
+	}
+	instanceStatus, err := s.ec2Client.DescribeInstanceStatus(params)
+	if err != nil {
+		return false, parseAwsError(err)
+	}
+	if len(instanceStatus.InstanceStatuses) != 1 {
+		return false, fmt.Errorf("Can't get the status of instanceId: %s", *instanceID)
+	}
+	return *instanceStatus.InstanceStatuses[0].InstanceState.Name == ec2.InstanceStateNameRunning, nil
 }
 
 func getBlkDevList() (map[string]bool, error) {
@@ -526,4 +543,17 @@ func (s *ebsService) GetTags(resourceID string) (map[string]string, error) {
 		result[*tag.Key] = *tag.Value
 	}
 	return result, nil
+}
+
+func (s *ebsService) DetachVolumeFromInstance(volumeID *string, instanceID *string) error {
+	params := &ec2.DetachVolumeInput{
+		VolumeId:   volumeID,
+		InstanceId: instanceID,
+	}
+
+	if _, err := s.ec2Client.DetachVolume(params); err != nil {
+		return parseAwsError(err)
+	}
+
+	return s.waitForVolumeTransition(*volumeID, ec2.VolumeStateInUse, ec2.VolumeStateAvailable)
 }

--- a/k8s-client/main.go
+++ b/k8s-client/main.go
@@ -1,0 +1,30 @@
+package main
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/rancher/convoy/api"
+	"github.com/rancher/convoy/client"
+)
+
+var (
+	VERSION = "0.5.0-dev"
+)
+
+func cleanup() {
+	if r := recover(); r != nil {
+		api.ResponseLogAndError(r)
+		os.Exit(1)
+	}
+}
+
+func main() {
+	defer cleanup()
+
+	cli := client.NewK8sCli(VERSION)
+	err := cli.Run(os.Args)
+	if err != nil {
+		panic(fmt.Errorf("Error when executing command: %v", err))
+	}
+}

--- a/scripts/build
+++ b/scripts/build
@@ -11,3 +11,8 @@ mkdir -p bin
 go build -a -tags "netgo libdm_no_deferred_remove" \
 	-ldflags "-X main.VERSION=$VERSION -linkmode external -extldflags -static" \
 	--installsuffix netgo -o bin/convoy
+
+cd k8s-client
+go build -a -tags "netgo libdm_no_deferred_remove" \
+	-ldflags "-X main.VERSION=$VERSION -linkmode external -extldflags -static" \
+	--installsuffix netgo -o ../bin/k8s

--- a/util/volume.go
+++ b/util/volume.go
@@ -113,8 +113,8 @@ func getVolumeOps(obj interface{}) (VolumeHelper, error) {
 	return ops, nil
 }
 
-func isMounted(mountPoint string) bool {
-	output, err := callMount([]string{}, []string{})
+func IsMounted(mountPoint string) bool {
+	output, err := CallMount([]string{}, []string{})
 	if err != nil {
 		return false
 	}
@@ -148,20 +148,20 @@ func VolumeMount(v interface{}, mountPoint string, remount bool) (string, error)
 	if existMount != "" && existMount != mountPoint {
 		return "", fmt.Errorf("Volume %v was already mounted at %v, but asked to mount at %v", getVolumeName(vol), existMount, mountPoint)
 	}
-	if remount && isMounted(mountPoint) {
+	if remount && IsMounted(mountPoint) {
 		log.Debugf("Umount existing mountpoint %v", mountPoint)
-		if err := callUmount([]string{mountPoint}); err != nil {
+		if err := CallUmount([]string{mountPoint}); err != nil {
 			return "", err
 		}
 	}
 	if createMountpoint {
-		if err := callMkdirIfNotExists(mountPoint); err != nil {
+		if err := CallMkdirIfNotExists(mountPoint); err != nil {
 			return "", err
 		}
 	}
-	if !isMounted(mountPoint) {
+	if !IsMounted(mountPoint) {
 		log.Debugf("Volume %v is being mounted it to %v, with option %v", getVolumeName(vol), mountPoint, opts)
-		_, err = callMount(opts, []string{dev, mountPoint})
+		_, err = CallMount(opts, []string{dev, mountPoint})
 		if err != nil {
 			return "", err
 		}
@@ -180,7 +180,7 @@ func VolumeUmount(v interface{}) error {
 		log.Debugf("Umount a umounted volume %v", getVolumeName(vol))
 		return nil
 	}
-	if err := callUmount([]string{mountPoint}); err != nil {
+	if err := CallUmount([]string{mountPoint}); err != nil {
 		return err
 	}
 	if mountPoint == vol.GenerateDefaultMountPoint() {
@@ -192,7 +192,7 @@ func VolumeUmount(v interface{}) error {
 	return nil
 }
 
-func callMkdirIfNotExists(dirName string) error {
+func CallMkdirIfNotExists(dirName string) error {
 	cmdName := "mkdir"
 	cmdArgs := []string{"-p", dirName}
 	cmdName, cmdArgs = updateMountNamespace(cmdName, cmdArgs)
@@ -203,7 +203,7 @@ func callMkdirIfNotExists(dirName string) error {
 	return nil
 }
 
-func callMount(opts, args []string) (string, error) {
+func CallMount(opts, args []string) (string, error) {
 	cmdName := MOUNT_BINARY
 	cmdArgs := opts
 	cmdArgs = append(cmdArgs, args...)
@@ -215,7 +215,7 @@ func callMount(opts, args []string) (string, error) {
 	return output, nil
 }
 
-func callUmount(args []string) error {
+func CallUmount(args []string) error {
 	cmdName := UMOUNT_BINARY
 	cmdArgs := args
 	cmdName, cmdArgs = updateMountNamespace(cmdName, cmdArgs)

--- a/vfs/vfs_storage.go
+++ b/vfs/vfs_storage.go
@@ -207,6 +207,7 @@ func (d *Driver) CreateVolume(req Request) error {
 		return err
 	}
 	if exists {
+		log.Debugf("volume name: %s exists!", volume.Name)
 		return nil
 	}
 
@@ -240,6 +241,7 @@ func (d *Driver) CreateVolume(req Request) error {
 			return err
 		}
 	}
+	log.Debugf("created volume name: %s", volume.Name)
 	return util.ObjectSave(volume)
 }
 
@@ -286,14 +288,26 @@ func (d *Driver) MountVolume(req Request) (string, error) {
 	if err := util.ObjectLoad(volume); err != nil {
 		return "", err
 	}
+	specifiedMountPoint := opts[OPT_MOUNT_POINT]
+	bindMount := opts[OPT_BIND_MOUNT]
+	if bindMount == "" {
+		if specifiedMountPoint != "" {
+			return "", fmt.Errorf("VFS doesn't support specified mount point if not bind mount")
+		}
+		if volume.MountPoint == "" {
+			volume.MountPoint = volume.Path
+		}
+	} else {
+		if specifiedMountPoint == "" {
+			return "", nil
+		}
+		mountPoint, err := d.bindMount(volume, opts)
+		if err != nil {
+			return "", err
+		}
+		volume.MountPoint = mountPoint
+	}
 
-	specifiedPoint := opts[OPT_MOUNT_POINT]
-	if specifiedPoint != "" {
-		return "", fmt.Errorf("VFS doesn't support specified mount point")
-	}
-	if volume.MountPoint == "" {
-		volume.MountPoint = volume.Path
-	}
 	if volume.PrepareForVM {
 		if err := util.MountPointPrepareImageFile(volume.MountPoint, volume.Size); err != nil {
 			return "", err
@@ -312,6 +326,54 @@ func (d *Driver) MountVolume(req Request) (string, error) {
 	return volume.MountPoint, nil
 }
 
+func (d *Driver) bindMount(volume *Volume, opts map[string]string) (string, error) {
+	mountPoint := opts[OPT_MOUNT_POINT]
+	remount := opts[OPT_REMOUNT]
+
+	// if existing mount point is the same as asked for, then do nothing
+	if volume.MountPoint == mountPoint && util.IsMounted(mountPoint) {
+		return mountPoint, nil
+	}
+	if volume.MountPoint != "" &&
+		util.IsMounted(volume.MountPoint) &&
+		volume.MountPoint != mountPoint &&
+		remount == "" {
+		// without remount option, can't bind mount a new mount point
+		return "", fmt.Errorf("Volume %v was already mounted at %v, but asked to mount at %v", volume.Name, volume.MountPoint, mountPoint)
+	}
+	if err := util.CallMkdirIfNotExists(mountPoint); err != nil {
+		return "", err
+	}
+	if volume.MountPoint != "" &&
+		util.IsMounted(volume.MountPoint) &&
+		remount != "" {
+		// unmount existing mount point
+		log.Debugf("Unmount existing mountpoint %v", volume.MountPoint)
+		if err := util.CallUmount([]string{volume.MountPoint}); err != nil {
+			return "", err
+		}
+	}
+	if err := d.doBindMount(volume, opts); err != nil {
+		return "", err
+	}
+	return mountPoint, nil
+}
+
+func (d *Driver) doBindMount(volume *Volume, opts map[string]string) error {
+	mountPoint := opts[OPT_MOUNT_POINT]
+	options := []string{"-o", opts[OPT_BIND_MOUNT]}
+	if opts[OPT_READ_WRITE] != "" {
+		options = append(options, "-o", opts[OPT_READ_WRITE])
+	}
+	log.Debugf("Volume %v is being mounted to %v, with option %v", volume.Name, mountPoint, options)
+
+	if _, err := util.CallMount(options, []string{volume.Path, mountPoint}); err != nil {
+		return err
+	}
+
+	return nil
+}
+
 func (d *Driver) UmountVolume(req Request) error {
 	d.mutex.Lock()
 	defer d.mutex.Unlock()
@@ -322,11 +384,13 @@ func (d *Driver) UmountVolume(req Request) error {
 	if err := util.ObjectLoad(volume); err != nil {
 		return err
 	}
-
-	if volume.MountPoint != "" {
-		volume.MountPoint = ""
+	if volume.MountPoint != "" && volume.MountPoint != volume.Path {
+		log.Debugf("CallUmount: %s", volume.MountPoint)
+		if err := util.CallUmount([]string{volume.MountPoint}); err != nil {
+			return err
+		}
 	}
-
+	volume.MountPoint = ""
 	lockFile, err := flock(volume)
 	if err != nil {
 		return fmt.Errorf("Coudln't get flock. Error: %v", err)

--- a/vfs/vfs_storage.go
+++ b/vfs/vfs_storage.go
@@ -82,6 +82,18 @@ func (v *Volume) ConfigFile() (string, error) {
 	return filepath.Join(v.configPath, VFS_CFG_PREFIX+VOLUME_CFG_PREFIX+v.Name+CFG_POSTFIX), nil
 }
 
+func (v *Volume) GetDevice() (string, error) {
+	return "", nil
+}
+
+func (v *Volume) GetMountOpts() []string {
+	return []string{}
+}
+
+func (v *Volume) GenerateDefaultMountPoint() string {
+	return ""
+}
+
 func (device *Device) listVolumeNames() ([]string, error) {
 	return util.ListConfigIDs(device.ConfigPath, VFS_CFG_PREFIX+VOLUME_CFG_PREFIX, CFG_POSTFIX)
 }
@@ -301,7 +313,12 @@ func (d *Driver) MountVolume(req Request) (string, error) {
 		if specifiedMountPoint == "" {
 			return "", nil
 		}
-		mountPoint, err := d.bindMount(volume, opts)
+		mountPoint, err := util.BindMountVolume(volume.Name,
+			volume.Path,
+			volume.MountPoint,
+			specifiedMountPoint,
+			bindMount,
+			opts[OPT_REMOUNT] != "")
 		if err != nil {
 			return "", err
 		}
@@ -326,54 +343,6 @@ func (d *Driver) MountVolume(req Request) (string, error) {
 	return volume.MountPoint, nil
 }
 
-func (d *Driver) bindMount(volume *Volume, opts map[string]string) (string, error) {
-	mountPoint := opts[OPT_MOUNT_POINT]
-	remount := opts[OPT_REMOUNT]
-
-	// if existing mount point is the same as asked for, then do nothing
-	if volume.MountPoint == mountPoint && util.IsMounted(mountPoint) {
-		return mountPoint, nil
-	}
-	if volume.MountPoint != "" &&
-		util.IsMounted(volume.MountPoint) &&
-		volume.MountPoint != mountPoint &&
-		remount == "" {
-		// without remount option, can't bind mount a new mount point
-		return "", fmt.Errorf("Volume %v was already mounted at %v, but asked to mount at %v", volume.Name, volume.MountPoint, mountPoint)
-	}
-	if err := util.CallMkdirIfNotExists(mountPoint); err != nil {
-		return "", err
-	}
-	if volume.MountPoint != "" &&
-		util.IsMounted(volume.MountPoint) &&
-		remount != "" {
-		// unmount existing mount point
-		log.Debugf("Unmount existing mountpoint %v", volume.MountPoint)
-		if err := util.CallUmount([]string{volume.MountPoint}); err != nil {
-			return "", err
-		}
-	}
-	if err := d.doBindMount(volume, opts); err != nil {
-		return "", err
-	}
-	return mountPoint, nil
-}
-
-func (d *Driver) doBindMount(volume *Volume, opts map[string]string) error {
-	mountPoint := opts[OPT_MOUNT_POINT]
-	options := []string{"-o", opts[OPT_BIND_MOUNT]}
-	if opts[OPT_READ_WRITE] != "" {
-		options = append(options, "-o", opts[OPT_READ_WRITE])
-	}
-	log.Debugf("Volume %v is being mounted to %v, with option %v", volume.Name, mountPoint, options)
-
-	if _, err := util.CallMount(options, []string{volume.Path, mountPoint}); err != nil {
-		return err
-	}
-
-	return nil
-}
-
 func (d *Driver) UmountVolume(req Request) error {
 	d.mutex.Lock()
 	defer d.mutex.Unlock()
@@ -385,8 +354,8 @@ func (d *Driver) UmountVolume(req Request) error {
 		return err
 	}
 	if volume.MountPoint != "" && volume.MountPoint != volume.Path {
-		log.Debugf("CallUmount: %s", volume.MountPoint)
-		if err := util.CallUmount([]string{volume.MountPoint}); err != nil {
+		log.Debugf("VolumeUmount: %s", volume.MountPoint)
+		if err := util.VolumeUmount(volume); err != nil {
 			return err
 		}
 	}


### PR DESCRIPTION
@yasker 

First part, it contains convoy changes in order to support k8s flex volume plugin, including daemon and API changes. It is supposed not to break existing convoy functionality.

- detach EBS volumes before attaching if they are not in-use
- expose File System type option to drivers when creating volumes
- add ReadWrite(ro, rw) mount options for all drivers
- add BindMount(-o bind) option for VFS driver that providing mountpoint
- add ReMount option together with BindMount option to allow a new mount point for k8s when it fails over a pod from one host to another

Second part, it contains k8s flex volume driver as a convoy client. There are some requirements from k8s driver side.

- driver must be a binary
- k8s invokes the driver with command(init, attach, detach, mount, unmount) as the first argument and then followed by command arguments in k8s format
- no stdout printout from driver at all except k8s required result status for each command
- Dependency:
- convoy daemon running with corresponding ebs and vfs drivers loaded

Second part code changes include:

- change build script to make a binary as a k8s volume driver plugin
- implement all required k8s volume plugin driver commands(init, attach, detach, mount, unmount) and k8s supported options
- driver uses rest API calls into convoy daemon to implement the functionalities inside convoy ebs/vfs drivers.
- a documentation file kubernetes.md to show how Flex Volume is defined by Kubernetes and how user can use this driver to integrate with Kubernetes