### PR TITLE
Revert "Ebs kms and storage types"

### DIFF
--- a/docs/ebs.md
+++ b/docs/ebs.md
@@ -19,8 +19,11 @@ At least please add permission for these actions:
 "ec2:DeleteVolume",
 "ec2:AttachVolume",
 "ec2:DetachVolume",
+"ec2:DescribeAvailabilityZones",
 "ec2:DescribeSnapshots",
 "ec2:DescribeTags",
+"ec2:DescribeVolumeAttribute",
+"ec2:DescribeVolumeStatus",
 "ec2:DescribeVolumes"
 ```
 
@@ -32,9 +35,6 @@ At least please add permission for these actions:
 `4G` by default. EBS volumes are 1GiB minimal and must be a multiple of 1GiB.
 #### `ebs.defaultvolumetype`
 `gp2` by default. See [Amazon EBS Volume Types](http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/EBSVolumeTypes.html) for details. Notice if user choose `io1` as default volume type, then user has to specify `--iops` when creating volume everytime.
-Other values are st1 and sc1.
-#### `ebs.defaultkmskeyid`
-Default is blank, if specified than volumes will be encrypted using the given kms key id.
 
 ## Command details
 ### `create`
@@ -61,7 +61,6 @@ Default is blank, if specified than volumes will be encrypted using the given km
 * `State`: EBS volume state. Should be `InUse` when it's attached to the current instance.
 * `Type`: EBS volume type.
 * `IOPS`: Input/Output Operations Per Second for EBS volume.
-* `KmsKeyId`: If the volume is encrypted, this specifies be the KMS key used.
 
 ### `snapshot create`
 `snapshot create` would create a new EBS snapshot of current EBS volume. The command would return immediately after it confirmed that creating of an EBS snapshot has been initated.
@@ -76,7 +75,6 @@ Default is blank, if specified than volumes will be encrypted using the given km
 * `StartTime`: Timestamp of start creating EBS snapshot
 * `Size`: Size of original EBS volume.
 * `State`: EBS snapshot state. Would be either `completed`, `error` or `pending`
-* `KmsKeyId`: If the snapshot is encrypted, this specifies the KMS key used.
 
 ### `backup create`
 `backup create` would wait for a EBS snapshot complete creating if it hasn't completed yet. If creation of snapshot was success, the command would return URL in the format of `ebs://<region>/snap-xxxxxxxx` represent the backup, which can be used with `create --backup` command later.
@@ -93,10 +91,9 @@ Default is blank, if specified than volumes will be encrypted using the given km
 * `StartTime`: Timestamp of start creating EBS snapshot
 * `Size`: Size of original EBS volume.
 * `State`: EBS snapshot state. Would be either `completed`, `error` or `pending`
-* `KmsKeyId`: If the snapshot is encrypted, this specifies the KMS key used.
 
 ## AWS tags
-Convoy uses the following bookeeping tags on EBS volume/snapshots which can be used to classify convoy managed resources.
+Convoy would use tags in EBS volume/snapshot to provide some insight of the volume in Convoy's perspect.
 
 ### EBS Volume
 * `Name`: Volume Name In Convoy

--- a/ebs/ebs.go
+++ b/ebs/ebs.go
@@ -27,7 +27,6 @@ const (
 
 	EBS_DEFAULT_VOLUME_SIZE = "ebs.defaultvolumesize"
 	EBS_DEFAULT_VOLUME_TYPE = "ebs.defaultvolumetype"
-	EBS_DEFAULT_VOLUME_KEY  = "ebs.defaultkmskeyid"
 
 	DEFAULT_VOLUME_SIZE = "4G"
 	DEFAULT_VOLUME_TYPE = "gp2"
@@ -47,7 +46,6 @@ type Device struct {
 	Root              string
 	DefaultVolumeSize int64
 	DefaultVolumeType string
-	DefaultKmsKeyID   string
 }
 
 func (dev *Device) ConfigFile() (string, error) {
@@ -115,8 +113,6 @@ func checkVolumeType(volumeType string) error {
 		"gp2":      true,
 		"io1":      true,
 		"standard": true,
-		"st1":      true,
-		"sc1":      true,
 	}
 	if !validVolumeType[volumeType] {
 		return fmt.Errorf("Invalid volume type %v", volumeType)
@@ -183,12 +179,10 @@ func Init(root string, config map[string]string) (ConvoyDriver, error) {
 		if err := checkVolumeType(volumeType); err != nil {
 			return nil, err
 		}
-		kmsKeyId := config[EBS_DEFAULT_VOLUME_KEY]
 		dev = &Device{
 			Root:              root,
 			DefaultVolumeSize: size,
 			DefaultVolumeType: volumeType,
-			DefaultKmsKeyID:   kmsKeyId,
 		}
 		if err := util.ObjectSave(dev); err != nil {
 			return nil, err
@@ -214,7 +208,6 @@ func (d *Driver) Info() (map[string]string, error) {
 	infos := make(map[string]string)
 	infos["DefaultVolumeSize"] = strconv.FormatInt(d.DefaultVolumeSize, 10)
 	infos["DefaultVolumeType"] = d.DefaultVolumeType
-	infos["DefaultKmsKey"] = d.DefaultKmsKeyID
 	infos["InstanceID"] = d.ebsService.InstanceID
 	infos["Region"] = d.ebsService.Region
 	infos["AvailiablityZone"] = d.ebsService.AvailabilityZone
@@ -362,13 +355,12 @@ func (d *Driver) CreateVolume(req Request) error {
 			VolumeType: volumeType,
 			IOPS:       iops,
 			Tags:       newTags,
-			KmsKeyID:   d.DefaultKmsKeyID,
 		}
 		volumeID, err = d.ebsService.CreateVolume(r)
 		if err != nil {
 			return err
 		}
-		log.Debugf("Created volume %s from EBS volume %v", id, volumeID)
+		log.Debugf("Created volume %v from EBS volume %v", id, volumeID)
 		format = true
 	}
 
@@ -498,7 +490,6 @@ func (d *Driver) GetVolumeInfo(id string) (map[string]string, error) {
 		"Device":                volume.Device,
 		"MountPoint":            volume.MountPoint,
 		"EBSVolumeID":           volume.EBSID,
-		"KmsKeyId":              *ebsVolume.KmsKeyId,
 		"AvailiablityZone":      *ebsVolume.AvailabilityZone,
 		OPT_VOLUME_NAME:         id,
 		OPT_VOLUME_CREATED_TIME: (*ebsVolume.CreateTime).Format(time.RubyDate),
@@ -507,7 +498,6 @@ func (d *Driver) GetVolumeInfo(id string) (map[string]string, error) {
 		"Type":                  *ebsVolume.VolumeType,
 		"IOPS":                  iops,
 	}
-
 	return info, nil
 }
 
@@ -648,7 +638,6 @@ func (d *Driver) getSnapshotInfo(id, volumeID string) (map[string]string, error)
 			"VolumeName":              volumeID,
 			"EBSSnapshotID":           *ebsSnapshot.SnapshotId,
 			"EBSVolumeID":             *ebsSnapshot.VolumeId,
-			"KmsKeyId":                *ebsSnapshot.KmsKeyId,
 			OPT_SNAPSHOT_CREATED_TIME: (*ebsSnapshot.StartTime).Format(time.RubyDate),
 			OPT_SIZE:                  strconv.FormatInt(*ebsSnapshot.VolumeSize*GB, 10),
 			"State":                   *ebsSnapshot.State,
@@ -772,7 +761,6 @@ func (d *Driver) GetBackupInfo(backupURL string) (map[string]string, error) {
 		"Region":        region,
 		"EBSSnapshotID": *ebsSnapshot.SnapshotId,
 		"EBSVolumeID":   *ebsSnapshot.VolumeId,
-		"KmsKeyId":      *ebsSnapshot.KmsKeyId,
 		"StartTime":     (*ebsSnapshot.StartTime).Format(time.RubyDate),
 		"Size":          strconv.FormatInt(*ebsSnapshot.VolumeSize*GB, 10),
 		"State":         *ebsSnapshot.State,

--- a/ebs/ebs_service.go
+++ b/ebs/ebs_service.go
@@ -39,7 +39,6 @@ type CreateEBSVolumeRequest struct {
 	SnapshotID string
 	VolumeType string
 	Tags       map[string]string
-	KmsKeyID   string
 }
 
 type CreateSnapshotRequest struct {
@@ -163,7 +162,6 @@ func (s *ebsService) CreateVolume(request *CreateEBSVolumeRequest) (string, erro
 	iops := request.IOPS
 	snapshotID := request.SnapshotID
 	volumeType := request.VolumeType
-	kmsKeyID := request.KmsKeyID
 
 	// EBS size are in GB, we would round it up
 	ebsSize := size / GB
@@ -175,17 +173,12 @@ func (s *ebsService) CreateVolume(request *CreateEBSVolumeRequest) (string, erro
 		AvailabilityZone: aws.String(s.AvailabilityZone),
 		Size:             aws.Int64(ebsSize),
 	}
-
 	if snapshotID != "" {
 		params.SnapshotId = aws.String(snapshotID)
-	} else if kmsKeyID != "" {
-		params.KmsKeyId = aws.String(kmsKeyID)
-		params.Encrypted = aws.Bool(true)
 	}
-
 	if volumeType != "" {
-		if err := checkVolumeType(volumeType); err != nil {
-			return "", err
+		if volumeType != "gp2" && volumeType != "io1" && volumeType != "standard" {
+			return "", fmt.Errorf("Invalid volume type for EBS: %v", volumeType)
 		}
 		if volumeType == "io1" && iops == 0 {
 			return "", fmt.Errorf("Invalid IOPS for volume type io1")


### PR DESCRIPTION
Reverts rancher/convoy#154 

This is breaking Convoy for all volumes created using convoy before this merge. The committer needs to find a better way to handle KMSKeyIDs, it is not a device configuration to be applied to all volumes by force.