### PR TITLE
Add multi pool type to create volume and surport yaml or json profile to start daemon

### DIFF
--- a/Dockerfile.dapper
+++ b/Dockerfile.dapper
@@ -26,6 +26,7 @@ ENV GOPATH=/go
 # Go tools
 RUN go get github.com/rancher/trash
 RUN go get github.com/golang/lint/golint
+RUN go get github.com/ghodss/yaml
 
 # Docker
 RUN curl -sL https://get.docker.com/builds/Linux/x86_64/docker-1.9.1 > /usr/bin/docker && \

--- a/api/request.go
+++ b/api/request.go
@@ -12,7 +12,7 @@ type VolumeUmountRequest struct {
 
 type VolumeCreateRequest struct {
 	Name           string
-	DriverName     string
+	StorageType    string
 	Size           int64
 	BackupURL      string
 	DriverVolumeID string

--- a/api/response.go
+++ b/api/response.go
@@ -17,6 +17,7 @@ type ErrorResponse struct {
 type VolumeResponse struct {
 	Name        string
 	Driver      string
+	StorageType string
 	MountPoint  string
 	CreatedTime string
 	DriverInfo  map[string]string

--- a/client/client.go
+++ b/client/client.go
@@ -147,6 +147,7 @@ func NewCli(version string) *cli.App {
 		volumeMountCmd,
 		volumeUmountCmd,
 		volumeListCmd,
+		volumeListTypeCmd,
 		volumeInspectCmd,
 		snapshotCmd,
 		backupCmd,

--- a/client/flags/flags.go
+++ b/client/flags/flags.go
@@ -19,15 +19,9 @@ var (
 			Value: "/var/lib/rancher/convoy",
 			Usage: "specific root directory of convoy, if configure file exists, daemon specific options would be ignored",
 		},
-		cli.StringSliceFlag{
-			Name:  "drivers",
-			Value: &cli.StringSlice{},
-			Usage: "Drivers to be enabled, first driver in the list would be treated as default driver",
-		},
-		cli.StringSliceFlag{
-			Name:  "driver-opts",
-			Value: &cli.StringSlice{},
-			Usage: "options for driver",
+		cli.StringFlag{
+			Name:  "config",
+			Usage: "Config filename for driver",
 		},
 		cli.StringFlag{
 			Name:  "mnt-ns",

--- a/client/volume.go
+++ b/client/volume.go
@@ -88,6 +88,18 @@ var (
 		Action: cmdVolumeList,
 	}
 
+	volumeListTypeCmd = cli.Command{
+		Name:  "list-type",
+		Usage: "list all storage type",
+		Flags: []cli.Flag{
+			cli.BoolFlag{
+				Name:  "storagetype",
+				Usage: "Ask for storagetype",
+			},
+		},
+		Action: cmdTypeList,
+	}
+
 	volumeInspectCmd = cli.Command{
 		Name:   "inspect",
 		Usage:  "inspect a certain volume: inspect <volume>",
@@ -187,6 +199,22 @@ func doVolumeList(c *cli.Context) error {
 	}
 
 	url := "/volumes/list?" + v.Encode()
+	return sendRequestAndPrint("GET", url, nil)
+}
+
+func cmdTypeList(c *cli.Context) {
+	if err := doTypeList(c); err != nil {
+		panic(err)
+	}
+}
+
+func doTypeList(c *cli.Context) error {
+	v := url.Values{}
+	if c.Bool("storagetype") {
+		v.Set("storagetype", "1")
+	}
+
+	url := "/storagetype/list?" + v.Encode()
 	return sendRequestAndPrint("GET", url, nil)
 }
 

--- a/client/volume.go
+++ b/client/volume.go
@@ -15,8 +15,8 @@ var (
 		Usage: "create a new volume: create [volume_name] [options]",
 		Flags: []cli.Flag{
 			cli.StringFlag{
-				Name:  "driver",
-				Usage: "specify using driver other than default",
+				Name:  "storagetype",
+				Usage: "specify using storagetype",
 			},
 			cli.StringFlag{
 				Name:  "size",
@@ -81,7 +81,7 @@ var (
 		Usage: "list all managed volumes",
 		Flags: []cli.Flag{
 			cli.BoolFlag{
-				Name:  "driver",
+				Name:  "storagetype",
 				Usage: "Ask for driver specific info of volumes and snapshots",
 			},
 		},
@@ -114,7 +114,7 @@ func doVolumeCreate(c *cli.Context) error {
 
 	name := c.Args().First()
 	size, err := getSize(c, err)
-	driverName, err := util.GetFlag(c, "driver", false, err)
+	typeName, err := util.GetFlag(c, "storagetype", false, err)
 	backupURL, err := util.GetFlag(c, "backup", false, err)
 	if err != nil {
 		return err
@@ -127,7 +127,7 @@ func doVolumeCreate(c *cli.Context) error {
 
 	request := &api.VolumeCreateRequest{
 		Name:           name,
-		DriverName:     driverName,
+		StorageType:    typeName,
 		Size:           size,
 		BackupURL:      backupURL,
 		DriverVolumeID: driverVolumeID,
@@ -182,8 +182,8 @@ func cmdVolumeList(c *cli.Context) {
 
 func doVolumeList(c *cli.Context) error {
 	v := url.Values{}
-	if c.Bool("driver") {
-		v.Set("driver", "1")
+	if c.Bool("storagetype") {
+		v.Set("storagetype", "1")
 	}
 
 	url := "/volumes/list?" + v.Encode()

--- a/convoydriver/convoydriver.go
+++ b/convoydriver/convoydriver.go
@@ -17,7 +17,7 @@ instance, and it would return a valid ConvoyDriver for operation.
 The registered function would take a "root" path, used as driver's configuration
 file path, and a map of configuration specified for the driver.
 */
-type InitFunc func(root string, config map[string]string) (ConvoyDriver, error)
+type InitFunc func(root string, config interface{}) (ConvoyDriver, error)
 
 /*
 ConvoyDriver interface would provide all the functionality needed for driver
@@ -29,9 +29,9 @@ driver.
 type ConvoyDriver interface {
 	Name() string
 	Info() (map[string]string, error)
-
-	VolumeOps() (VolumeOperations, error)
+	Storage() string
 	SnapshotOps() (SnapshotOperations, error)
+	VolumeOps() (VolumeOperations, error)
 	BackupOps() (BackupOperations, error)
 }
 
@@ -89,6 +89,7 @@ const (
 	OPT_VOLUME_DRIVER_ID      = "VolumeDriverID"
 	OPT_VOLUME_TYPE           = "VolumeType"
 	OPT_VOLUME_IOPS           = "VolumeIOPS"
+	OPT_VOLUME_STORAGETYPE    = "VolumeStorageType"
 	OPT_VOLUME_CREATED_TIME   = "VolumeCreatedAt"
 	OPT_SNAPSHOT_NAME         = "SnapshotName"
 	OPT_SNAPSHOT_CREATED_TIME = "SnapshotCreatedAt"
@@ -121,10 +122,10 @@ func Register(name string, initFunc InitFunc) error {
 /*
 GetDriver would be called each time when a Convoy Driver instance is needed.
 */
-func GetDriver(name, root string, config map[string]string) (ConvoyDriver, error) {
-	if _, exists := initializers[name]; !exists {
-		return nil, fmt.Errorf("Driver %v is not supported!", name)
+func GetDriver(typeName, driver, root string, config interface{}) (ConvoyDriver, error) {
+	if _, exists := initializers[driver]; !exists {
+		return nil, fmt.Errorf("Driver %v is not supported!", driver)
 	}
-	drvRoot := filepath.Join(root, name)
-	return initializers[name](drvRoot, config)
+	drvRoot := filepath.Join(root, typeName)
+	return initializers[driver](drvRoot, config)
 }

--- a/convoydriver/poolconfig.go
+++ b/convoydriver/poolconfig.go
@@ -1,0 +1,12 @@
+package convoydriver
+
+type ThinPoolConfig struct {
+    Driver             string	`json:"driver", omitempty`
+    StorageType        string	`json:"storageType", omitempty`
+    ThinPoolMetaDevice string	`json:"thinPoolMetaDevice", omitempty`
+    ThinPoolDataDevice string	`json:"thinPoolDataDevice", omitempty`
+    BlockSize          string	`json:"blockSize", omitempty`
+    VolumeSize         string	`json:"volumeSize", omitempty`
+    FileSystem         string	`json:"fileSystem", omitempty`
+}
+

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -80,6 +80,7 @@ func createRouter(s *daemon) *mux.Router {
 		"GET": {
 			"/info":            s.doInfo,
 			"/volumes/list":    s.doVolumeList,
+			"/storagetype/list":s.doTypeList,
 			"/volumes/":        s.doVolumeInspect,
 			"/snapshots/":      s.doSnapshotInspect,
 			"/backups/list":    s.doBackupList,

--- a/daemon/docker.go
+++ b/daemon/docker.go
@@ -77,7 +77,7 @@ func (s *daemon) createDockerVolume(request *pluginRequest) (*Volume, error) {
 	}
 	createReq := &api.VolumeCreateRequest{
 		Name:           name,
-		DriverName:     request.Opts["driver"],
+		StorageType:    request.Opts["storagetype"],
 		Size:           size,
 		BackupURL:      request.Opts["backup"],
 		DriverVolumeID: request.Opts["id"],

--- a/daemon/volume.go
+++ b/daemon/volume.go
@@ -14,8 +14,9 @@ import (
 )
 
 type Volume struct {
-	Name       string
-	DriverName string
+	Name        string
+	DriverName      string
+	StorageType string
 }
 
 var notFoundAPIError = APIError{
@@ -24,14 +25,15 @@ var notFoundAPIError = APIError{
 }
 
 func (s *daemon) getVolume(name string) *Volume {
-	driver, err := s.getDriverForVolume(name)
+	storage, err := s.getDriverForVolume(name)
 	if err != nil {
 		return nil
 	}
 
 	return &Volume{
 		Name:       name,
-		DriverName: driver.Name(),
+		StorageType: storage.Storage(),
+		DriverName: storage.Name(),
 	}
 }
 
@@ -73,8 +75,7 @@ func (s *daemon) generateName() (string, error) {
 
 func (s *daemon) processVolumeCreate(request *api.VolumeCreateRequest) (*Volume, error) {
 	volumeName := request.Name
-	driverName := request.DriverName
-
+	storageType := request.StorageType
 	var err error
 	if volumeName == "" {
 		volumeName, err = s.generateName()
@@ -91,14 +92,14 @@ func (s *daemon) processVolumeCreate(request *api.VolumeCreateRequest) (*Volume,
 		}
 	}
 
-	if driverName == "" {
-		driverName = s.DefaultDriver
+	if storageType == "" {
+		return nil, fmt.Errorf("Volume don't specifit --storagetype")
 	}
-	driver, err := s.getDriver(driverName)
+	storagetype, err := s.getDriver(storageType)
 	if err != nil {
 		return nil, err
 	}
-	volOps, err := driver.VolumeOps()
+	volOps, err := storagetype.VolumeOps()
 	if err != nil {
 		return nil, err
 	}
@@ -111,6 +112,7 @@ func (s *daemon) processVolumeCreate(request *api.VolumeCreateRequest) (*Volume,
 			OPT_VOLUME_NAME:      volumeName,
 			OPT_VOLUME_DRIVER_ID: request.DriverVolumeID,
 			OPT_VOLUME_TYPE:      request.Type,
+			OPT_VOLUME_STORAGETYPE: storageType,
 			OPT_VOLUME_IOPS:      strconv.FormatInt(request.IOPS, 10),
 			OPT_PREPARE_FOR_VM:   strconv.FormatBool(request.PrepareForVM),
 		},
@@ -134,7 +136,8 @@ func (s *daemon) processVolumeCreate(request *api.VolumeCreateRequest) (*Volume,
 
 	volume := &Volume{
 		Name:       volumeName,
-		DriverName: driverName,
+		StorageType: storageType,
+		DriverName: storagetype.Name(),
 	}
 
 	if err := s.NameUUIDIndex.Add(volumeName, "exists"); err != nil {
@@ -161,6 +164,7 @@ func (s *daemon) doVolumeCreate(version string, w http.ResponseWriter, r *http.R
 	if request.Verbose {
 		return writeResponseOutput(w, api.VolumeResponse{
 			Name:        volume.Name,
+			StorageType: volume.StorageType,
 			Driver:      volume.DriverName,
 			CreatedTime: driverInfo[OPT_VOLUME_CREATED_TIME],
 			DriverInfo:  driverInfo,
@@ -254,6 +258,7 @@ func (s *daemon) listVolumeInfo(volume *Volume) (*api.VolumeResponse, error) {
 	resp := &api.VolumeResponse{
 		Name:        volume.Name,
 		Driver:      volume.DriverName,
+		StorageType: volume.StorageType,
 		MountPoint:  mountPoint,
 		CreatedTime: driverInfo[OPT_VOLUME_CREATED_TIME],
 		DriverInfo:  driverInfo,
@@ -265,7 +270,7 @@ func (s *daemon) listVolumeInfo(volume *Volume) (*api.VolumeResponse, error) {
 		return resp, nil
 	}
 	for name, snapshot := range snapshots {
-		snapshot["Driver"] = volOps.Name()
+		snapshot["StorageType"] = volOps.Name()
 		resp.Snapshots[name] = api.SnapshotResponse{
 			Name:        name,
 			CreatedTime: snapshot[OPT_SNAPSHOT_CREATED_TIME],
@@ -300,22 +305,22 @@ func (s *daemon) getVolumeDriverInfo(volume *Volume) (map[string]string, error) 
 	if err != nil {
 		return nil, err
 	}
-	driverInfo, err := volOps.GetVolumeInfo(volume.Name)
+	DriverInfo, err := volOps.GetVolumeInfo(volume.Name)
 	if err != nil {
 		return nil, err
 	}
-	driverInfo["Driver"] = volOps.Name()
-	return driverInfo, nil
+	DriverInfo["Driver"] = volOps.Name()
+	return DriverInfo, nil
 }
 
 func (s *daemon) doVolumeList(version string, w http.ResponseWriter, r *http.Request, objs map[string]string) error {
-	driverSpecific, err := util.GetFlag(r, "driver", false, nil)
+	storageSpecific, err := util.GetFlag(r, "StorageType", false, nil)
 	if err != nil {
 		return err
 	}
 
 	var data []byte
-	if driverSpecific == "1" {
+	if storageSpecific == "1" {
 		result := s.getVolumeList()
 		data, err = api.ResponseOutput(&result)
 	} else {
@@ -532,7 +537,7 @@ func (s *daemon) getVolumeList() map[string]map[string]string {
 			break
 		}
 		for k, v := range volumes {
-			v["Driver"] = driver.Name()
+			v["storagetype"] = driver.Storage()
 			result[k] = v
 		}
 	}

--- a/daemon/volume.go
+++ b/daemon/volume.go
@@ -333,6 +333,16 @@ func (s *daemon) doVolumeList(version string, w http.ResponseWriter, r *http.Req
 	return err
 }
 
+func (s *daemon) doTypeList(version string, w http.ResponseWriter, r *http.Request, objs map[string]string) error {
+	result := ""
+	for _, driver := range s.ConvoyDrivers {
+		result = result + driver.Storage() + " "
+	}
+	data, err := api.ResponseOutput(&result)
+	_, err = w.Write(data)
+	return err
+}
+
 func (s *daemon) inspectVolume(name string) ([]byte, error) {
 	volume := s.getVolume(name)
 	if volume == nil {

--- a/devmapper/devmapper_test.go
+++ b/devmapper/devmapper_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/rancher/convoy/util"
 
 	. "gopkg.in/check.v1"
+	"github.com/rancher/convoy/daemon"
 )
 
 const (
@@ -130,20 +131,19 @@ func (s *TestSuite) TearDownSuite(c *C) {
 }
 
 func (s *TestSuite) initDriver(c *C) {
-	config := make(map[string]string)
+	config := daemon.ThinPoolConfig{}
 
 	_, err := Init(devCfgRoot, config)
 	c.Assert(err, ErrorMatches, "data device or metadata device unspecified")
 
-	config[DM_DATA_DEV] = s.dataDev
-	config[DM_METADATA_DEV] = s.metadataDev
-	config[DM_THINPOOL_BLOCK_SIZE] = "100"
+	config.ThinPoolDataDevice = s.dataDev
+	config.ThinPoolMetaDevice = s.metadataDev
+	config.BlockSize = "100"
 	_, err = Init(devCfgRoot, config)
 	c.Assert(err, Not(IsNil))
 	c.Assert(err, ErrorMatches, "Block size must.*")
 
-	config[DM_THINPOOL_NAME] = "test_pool"
-	delete(config, DM_THINPOOL_BLOCK_SIZE)
+	config.BlockSize = ""
 
 	driver, err := Init(devCfgRoot, config)
 	c.Assert(err, IsNil)

--- a/digitalocean/digitalocean.go
+++ b/digitalocean/digitalocean.go
@@ -41,6 +41,7 @@ type Driver struct {
 type Device struct {
 	Root              string
 	DefaultVolumeSize int64
+	StorageType       string
 }
 
 func (d *Device) ConfigFile() (string, error) {
@@ -120,7 +121,11 @@ func init() {
 	Register(DRIVER_NAME, Init)
 }
 
-func Init(root string, config map[string]string) (ConvoyDriver, error) {
+func Init(root string, v interface{}) (ConvoyDriver, error) {
+	config, ok := v.(map[string]string)
+	if !ok {
+		return nil, fmt.Errorf("config is not a map")
+	}
 	dev := &Device{
 		Root: root,
 	}
@@ -179,6 +184,10 @@ func (d *Driver) Info() (map[string]string, error) {
 		"DefaultVolumeSize": strconv.FormatInt(d.DefaultVolumeSize, 10),
 	}
 	return ret, nil
+}
+
+func (d *Driver) Storage() string {
+	return d.StorageType
 }
 
 func (d *Driver) VolumeOps() (VolumeOperations, error) {

--- a/docs/cli_reference.md
+++ b/docs/cli_reference.md
@@ -36,8 +36,7 @@ OPTIONS:
    --debug							Debug log, enabled by default
    --log 							specific output log file, otherwise output to stdout by default
    --root "/var/lib/convoy"					specific root directory of convoy, if configure file exists, daemon specific options would be ignored
-   --drivers [--drivers option --drivers option]		Drivers to be enabled, first driver in the list would be treated as default driver
-   --driver-opts [--driver-opts option --driver-opts option]	options for driver
+   --config                         Config filename for driver
 ```
 1. ```daemon``` command would start the Convoy daemon.The same Convoy binary would be used to start daemon as well as used as the client to communicate with daemon. In order to use Convoy, user need to setup and start the Convoy daemon first. Convoy daemon would run in the foreground by default. User can use various method e.g. [init-script](https://github.com/fhd/init-script-template) to start Convoy as background daemon.
 2. ```--root``` option would specify Convoy daemon's config root directory. After start Convoy on the host for the first time, it would contains all the information necessary for Convoy to start. After first time of start up, ```convoy daemon``` would automatically load configuration from config root directory. User don't need to specify same configurations anymore.
@@ -62,7 +61,7 @@ USAGE:
    command create [command options] [arguments...]
 
 OPTIONS:
-   --driver 	specify using driver other than default
+   --storagetype        specify using storagetype
    --size 	size of volume if driver supports, in bytes, or end in either G or M or K
    --backup 	create a volume of backup if driver supports
    --id 	driver specific volume ID if driver supports

--- a/ebs/ebs.go
+++ b/ebs/ebs.go
@@ -50,6 +50,7 @@ type Device struct {
 	DefaultVolumeSize int64
 	DefaultVolumeType string
 	DefaultKmsKeyID   string
+	StorageType       string
 }
 
 func (dev *Device) ConfigFile() (string, error) {
@@ -80,6 +81,10 @@ func (d *Driver) blankVolume(name string) *Volume {
 		configPath: d.Root,
 		Name:       name,
 	}
+}
+
+func (d *Driver) Storage() string {
+	return d.StorageType
 }
 
 func (v *Volume) ConfigFile() (string, error) {
@@ -150,7 +155,11 @@ func (d *Driver) remountVolumes() error {
 	return err
 }
 
-func Init(root string, config map[string]string) (ConvoyDriver, error) {
+func Init(root string, v interface{}) (ConvoyDriver, error) {
+	config, ok := v.(map[string]string)
+	if !ok {
+		return nil, fmt.Errorf("config is not a map")
+	}
 	ebsService, err := NewEBSService()
 	if err != nil {
 		return nil, err

--- a/glusterfs/glusterfs.go
+++ b/glusterfs/glusterfs.go
@@ -50,11 +50,16 @@ func (d *Driver) Name() string {
 	return DRIVER_NAME
 }
 
+func (d *Driver) Storage() string {
+	return d.StorageType
+}
+
 type Device struct {
 	Root              string
 	Servers           []string
 	DefaultVolumePool string
 	DefaultVolumeSize int64
+	StorageType       string
 }
 
 func (dev *Device) ConfigFile() (string, error) {
@@ -115,7 +120,11 @@ func (device *Device) listVolumeNames() ([]string, error) {
 	return util.ListConfigIDs(device.Root, DRIVER_CFG_PREFIX+VOLUME_CFG_PREFIX, CFG_POSTFIX)
 }
 
-func Init(root string, config map[string]string) (ConvoyDriver, error) {
+func Init(root string, v interface{}) (ConvoyDriver, error) {
+	config, ok := v.(map[string]string)
+	if !ok {
+		return nil, fmt.Errorf("config is not a map")
+	}
 	dev := &Device{
 		Root: root,
 	}

--- a/logging/logging.go
+++ b/logging/logging.go
@@ -28,6 +28,7 @@ const (
 	LOG_FIELD_FILEPATH      = "filepath"
 	LOG_FIELD_CONTEXT       = "context"
 	LOG_FIELD_OPTS          = "opts"
+	LOG_FIELD_TYPE          = "storagetype"
 
 	LOG_FIELD_EVENT      = "event"
 	LOG_EVENT_INIT       = "init"

--- a/vfs/vfs_storage.go
+++ b/vfs/vfs_storage.go
@@ -44,6 +44,7 @@ type Device struct {
 	Path              string
 	ConfigPath        string
 	DefaultVolumeSize int64
+	StorageType       string
 }
 
 func (dev *Device) ConfigFile() (string, error) {
@@ -51,6 +52,10 @@ func (dev *Device) ConfigFile() (string, error) {
 		return "", fmt.Errorf("BUG: Invalid empty device config path")
 	}
 	return filepath.Join(dev.Root, DRIVER_CONFIG_FILE), nil
+}
+
+func (d *Driver) Storage() string {
+	return d.StorageType
 }
 
 type Snapshot struct {
@@ -86,7 +91,11 @@ func (device *Device) listVolumeNames() ([]string, error) {
 	return util.ListConfigIDs(device.ConfigPath, VFS_CFG_PREFIX+VOLUME_CFG_PREFIX, CFG_POSTFIX)
 }
 
-func Init(root string, config map[string]string) (ConvoyDriver, error) {
+func Init(root string, v interface{}) (ConvoyDriver, error) {
+	config, ok := v.(map[string]string)
+	if !ok {
+		return nil, fmt.Errorf("config is not map")
+	}
 	dev := &Device{
 		Root: root,
 	}


### PR DESCRIPTION
    I add change the --driver and --dirver-opts option into yaml or json profile to start daemon. The same time, the profile can create different pool-type (I rename "storagetype") to create volume. Different pool-type can link to different backend (I just finish the devmapper). When the user create volume, he can specify pool by "--storagetype". Different storagetype has own cfg file and store in different file folder.
    I also add option of "convoy list-type" to list current storagetype.