### PR TITLE
Added ebs.defaultencrypted to volume creation opts.

### DIFF
--- a/docs/ebs.md
+++ b/docs/ebs.md
@@ -35,6 +35,9 @@ At least please add permission for these actions:
 Other values are st1 and sc1.
 #### `ebs.defaultkmskeyid`
 Default is blank, if specified than volumes will be encrypted using the given kms key id.
+Default is blank, if specified then volumes will be encrypted using the given kms key id.
+#### `ebs.defaultencrypted`
+`false` by default, if `true` then volumes will be encrypted with the default account kms key.
 
 ## Command details
 ### `create`

--- a/ebs/ebs.go
+++ b/ebs/ebs.go
@@ -30,6 +30,7 @@ const (
 	EBS_DEFAULT_VOLUME_SIZE = "ebs.defaultvolumesize"
 	EBS_DEFAULT_VOLUME_TYPE = "ebs.defaultvolumetype"
 	EBS_DEFAULT_VOLUME_KEY  = "ebs.defaultkmskeyid"
+	EBS_DEFAULT_ENCRYPTED   = "ebs.defaultencrypted"
 
 	DEFAULT_VOLUME_SIZE = "4G"
 	DEFAULT_VOLUME_TYPE = "gp2"
@@ -50,6 +51,7 @@ type Device struct {
 	DefaultVolumeSize int64
 	DefaultVolumeType string
 	DefaultKmsKeyID   string
+	DefaultEncrypted  bool
 }
 
 func (dev *Device) ConfigFile() (string, error) {
@@ -186,11 +188,18 @@ func Init(root string, config map[string]string) (ConvoyDriver, error) {
 			return nil, err
 		}
 		kmsKeyId := config[EBS_DEFAULT_VOLUME_KEY]
+		var encrypted bool
+		if encryptedStr, ok := config[EBS_DEFAULT_ENCRYPTED]; ok {
+			if encrypted, err = strconv.ParseBool(encryptedStr); err != nil {
+				return nil, err
+			}
+		}
 		dev = &Device{
 			Root:              root,
 			DefaultVolumeSize: size,
 			DefaultVolumeType: volumeType,
 			DefaultKmsKeyID:   kmsKeyId,
+			DefaultEncrypted:  encrypted,
 		}
 		if err := util.ObjectSave(dev); err != nil {
 			return nil, err
@@ -217,6 +226,7 @@ func (d *Driver) Info() (map[string]string, error) {
 	infos["DefaultVolumeSize"] = strconv.FormatInt(d.DefaultVolumeSize, 10)
 	infos["DefaultVolumeType"] = d.DefaultVolumeType
 	infos["DefaultKmsKey"] = d.DefaultKmsKeyID
+	infos["DefaultEncrypted"] = fmt.Sprint(d.DefaultEncrypted)
 	infos["InstanceID"] = d.ebsService.InstanceID
 	infos["Region"] = d.ebsService.Region
 	infos["AvailiablityZone"] = d.ebsService.AvailabilityZone

--- a/ebs/ebs_service.go
+++ b/ebs/ebs_service.go
@@ -40,6 +40,7 @@ type CreateEBSVolumeRequest struct {
 	VolumeType string
 	Tags       map[string]string
 	KmsKeyID   string
+	Encrypted  bool
 }
 
 type CreateSnapshotRequest struct {
@@ -174,6 +175,7 @@ func (s *ebsService) CreateVolume(request *CreateEBSVolumeRequest) (string, erro
 	params := &ec2.CreateVolumeInput{
 		AvailabilityZone: aws.String(s.AvailabilityZone),
 		Size:             aws.Int64(ebsSize),
+		Encrypted:        aws.Bool(request.Encrypted),
 	}
 
 	if snapshotID != "" {


### PR DESCRIPTION
Added ebs.defaultencrypted to volume creation opts.

Exposes `encrypted` AWS EBS volume API configuration controls, and allows volume encryption to be activated without needing to specify a specific KMS Key ID (signaling that the default account key be used).

Useful for cases where unilateral encryption of all convoy-managed volumes is desired.