### PR TITLE
Don't swallow errors in `init()' functions.

### DIFF
--- a/devmapper/devmapper.go
+++ b/devmapper/devmapper.go
@@ -139,7 +139,9 @@ func generateError(fields logrus.Fields, format string, v ...interface{}) error 
 }
 
 func init() {
-	Register(DRIVER_NAME, Init)
+	if err := Register(DRIVER_NAME, Init); err != nil {
+		panic(err)
+	}
 }
 
 func (device *Device) listVolumeNames() ([]string, error) {

--- a/digitalocean/digitalocean.go
+++ b/digitalocean/digitalocean.go
@@ -117,7 +117,9 @@ func (d *Driver) remountVolumes() error {
 }
 
 func init() {
-	Register(DRIVER_NAME, Init)
+	if err := Register(DRIVER_NAME, Init); err != nil {
+		panic(err)
+	}
 }
 
 func Init(root string, config map[string]string) (ConvoyDriver, error) {

--- a/ebs/ebs.go
+++ b/ebs/ebs.go
@@ -103,7 +103,9 @@ func (v *Volume) GenerateDefaultMountPoint() string {
 }
 
 func init() {
-	Register(DRIVER_NAME, Init)
+	if err := Register(DRIVER_NAME, Init); err != nil {
+		panic(err)
+	}
 }
 
 func generateError(fields logrus.Fields, format string, v ...interface{}) error {

--- a/ebs/ebs_service.go
+++ b/ebs/ebs_service.go
@@ -115,8 +115,7 @@ func (s *ebsService) waitForVolumeTransition(volumeID, start, end string) error 
 		}
 	}
 	if *volume.State != end {
-		return fmt.Errorf("Cannot finish volume %v state transition, ",
-			"from %v to %v, though final state %v",
+		return fmt.Errorf("Cannot finish volume %v state transition, from %v to %v, though final state %v",
 			volumeID, start, end, *volume.State)
 	}
 	return nil

--- a/glusterfs/glusterfs.go
+++ b/glusterfs/glusterfs.go
@@ -43,7 +43,9 @@ type Driver struct {
 }
 
 func init() {
-	Register(DRIVER_NAME, Init)
+	if err := Register(DRIVER_NAME, Init); err != nil {
+		panic(err)
+	}
 }
 
 func (d *Driver) Name() string {

--- a/s3/s3.go
+++ b/s3/s3.go
@@ -27,7 +27,9 @@ const (
 )
 
 func init() {
-	objectstore.RegisterDriver(KIND, initFunc)
+	if err := objectstore.RegisterDriver(KIND, initFunc); err != nil {
+		panic(err)
+	}
 }
 
 func initFunc(destURL string) (objectstore.ObjectStoreDriver, error) {

--- a/util/util.go
+++ b/util/util.go
@@ -315,7 +315,10 @@ func Execute(binary string, args []string) (string, error) {
 	case <-done:
 	case <-time.After(cmdTimeout):
 		if cmd.Process != nil {
-			cmd.Process.Kill()
+			if err := cmd.Process.Kill(); err != nil {
+				log.Warnf("Problem killing process pid=%v: %s", cmd.Process.Pid, err)
+			}
+
 		}
 		return "", fmt.Errorf("Timeout executing: %v %v, output %v, error %v", binary, args, string(output), err)
 	}

--- a/util/volume_test.go
+++ b/util/volume_test.go
@@ -91,7 +91,9 @@ func (s *TestSuite) TestVolumeHelper(c *C) {
 }
 
 func (s *TestSuite) TestVolumeHelperWithNamespace(c *C) {
-	InitMountNamespace("/proc/1/ns/mnt")
+	if err := InitMountNamespace("/proc/1/ns/mnt"); err != nil {
+		panic(err)
+	}
 	s.TestVolumeHelper(c)
 }
 

--- a/vfs/vfs_objectstore.go
+++ b/vfs/vfs_objectstore.go
@@ -31,7 +31,9 @@ const (
 )
 
 func init() {
-	objectstore.RegisterDriver(KIND, initFunc)
+	if err := objectstore.RegisterDriver(KIND, initFunc); err != nil {
+		panic(err)
+	}
 }
 
 func initFunc(destURL string) (objectstore.ObjectStoreDriver, error) {

--- a/vfs/vfs_storage.go
+++ b/vfs/vfs_storage.go
@@ -32,7 +32,9 @@ type Driver struct {
 }
 
 func init() {
-	Register(DRIVER_NAME, Init)
+	if err := Register(DRIVER_NAME, Init); err != nil {
+		panic(err)
+	}
 }
 
 func (d *Driver) Name() string {


### PR DESCRIPTION
Don't swallow errors in `init()' functions, panic instead.

Log non-fatal errors as warnings (rather than silently swallowing them).