### PR TITLE
Support sync() and fsfreeze()

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,9 @@
 # Folders
 _obj
 _test
+bin
+build
+dist
 
 # Architecture specific extensions/prefixes
 *.[568vq]

--- a/docs/development-without-golang.md
+++ b/docs/development-without-golang.md
@@ -1,0 +1,30 @@
+# Development Without Go
+
+You can build, test and package Convoy without needing a Linux machine with dependencies.  On a Mac for example,
+create a docker-machine that you can mount your host file system into.  Then
+
+```bash
+docker build -t convoy -f Dockerfile.dapper .
+```
+
+## Build
+
+```bash
+docker run --rm -v $(pwd):/go/src/github.com/rancher/convoy -it convoy
+```
+
+## Test
+
+```bash
+docker run --rm -v $(pwd):/go/src/github.com/rancher/convoy -it convoy test
+```
+
+## Package
+
+```bash
+docker run --rm -v $(pwd):/go/src/github.com/rancher/convoy -it convoy package
+```
+
+After running `package`, you will have "dist/artifacts/convoy.tar.gz" which you can install
+by following the directions in the main README.md.
+

--- a/docs/ebs.md
+++ b/docs/ebs.md
@@ -35,7 +35,8 @@ At least please add permission for these actions:
 Other values are st1 and sc1.
 #### `ebs.defaultkmskeyid`
 Default is blank, if specified than volumes will be encrypted using the given kms key id.
-
+#### `ebs.fsfreeze`
+Default is false.  If set to true, will perform a `/sbin/fsfreeze` on the filesystem before creating a snapshot, and unfreeze after the snapshot has been created.  This may yield a more consistent snapshot of a running application.  This uses `/sbin/fsfreeze` command which must be installed.  It is installed by default in Ubuntu 16.04 based docker images.
 ## Command details
 ### `create`
 * `--size` would specify the EBS volume size user want to create. EBS volumes are 1GiB minimal and must be a multiple of 1GiB.

--- a/ebs/ebs.go
+++ b/ebs/ebs.go
@@ -30,9 +30,11 @@ const (
 	EBS_DEFAULT_VOLUME_SIZE = "ebs.defaultvolumesize"
 	EBS_DEFAULT_VOLUME_TYPE = "ebs.defaultvolumetype"
 	EBS_DEFAULT_VOLUME_KEY  = "ebs.defaultkmskeyid"
+	EBS_FSFREEZE = "ebs.fsfreeze"
 
 	DEFAULT_VOLUME_SIZE = "4G"
 	DEFAULT_VOLUME_TYPE = "gp2"
+	DEFAULT_FSFREEZE = "false"
 
 	MOUNTS_DIR    = "mounts"
 	MOUNT_BINARY  = "mount"
@@ -50,6 +52,7 @@ type Device struct {
 	DefaultVolumeSize int64
 	DefaultVolumeType string
 	DefaultKmsKeyID   string
+	FsFreeze          string
 }
 
 func (dev *Device) ConfigFile() (string, error) {
@@ -186,11 +189,16 @@ func Init(root string, config map[string]string) (ConvoyDriver, error) {
 			return nil, err
 		}
 		kmsKeyId := config[EBS_DEFAULT_VOLUME_KEY]
+		if config[EBS_FSFREEZE] == "" {
+			config[EBS_FSFREEZE] = DEFAULT_FSFREEZE
+		}
+		fsFreeze := config[EBS_FSFREEZE]
 		dev = &Device{
 			Root:              root,
 			DefaultVolumeSize: size,
 			DefaultVolumeType: volumeType,
 			DefaultKmsKeyID:   kmsKeyId,
+			FsFreeze:          fsFreeze,
 		}
 		if err := util.ObjectSave(dev); err != nil {
 			return nil, err
@@ -578,9 +586,11 @@ func (d *Driver) CreateSnapshot(req Request) error {
 			return err
 		}
 
-		log.Debugf("freezing %v", volume.MountPoint)
-		if err := util.Freeze( volume.MountPoint ); err != nil {
-			return err
+		if d.FsFreeze == "true" {
+			log.Debugf("freezing %v", volume.MountPoint)
+			if err := util.Freeze( volume.MountPoint ); err != nil {
+				return err
+			}
 		}
 	}
 
@@ -599,9 +609,11 @@ func (d *Driver) CreateSnapshot(req Request) error {
 	}
 
 	if volume.MountPoint != "" {
-		log.Debugf("unfreezing %v", volume.MountPoint)
-		if err := util.UnFreeze( volume.MountPoint ); err != nil {
-			return err
+		if d.FsFreeze == "true" {
+			log.Debugf("unfreezing %v", volume.MountPoint)
+			if err := util.UnFreeze( volume.MountPoint ); err != nil {
+				return err
+			}
 		}
 	}
 	

--- a/util/util.go
+++ b/util/util.go
@@ -16,6 +16,7 @@ import (
 	"regexp"
 	"strconv"
 	"strings"
+	"syscall"
 	"time"
 
 	"github.com/Sirupsen/logrus"
@@ -95,6 +96,25 @@ func UnlockFile(f *os.File) error {
 		return err
 	}
 	if _, err := Execute("rm", []string{f.Name()}); err != nil {
+		return err
+	}
+	return nil
+}
+
+func Sync() error {
+	syscall.Sync()
+	return nil
+}
+
+func Freeze(mountpoint string) error {
+	if _, err := Execute("fsfreeze", []string{"-f", mountpoint}); err != nil {
+		return err
+	}
+	return nil
+}
+
+func UnFreeze(mountpoint string) error {
+	if _, err := Execute("fsfreeze", []string{"-u", mountpoint}); err != nil {
 		return err
 	}
 	return nil

--- a/vfs/vfs_storage.go
+++ b/vfs/vfs_storage.go
@@ -422,9 +422,18 @@ func (d *Driver) CreateSnapshot(req Request) error {
 	if err := util.MkdirIfNotExists(filepath.Dir(snapFile)); err != nil {
 		return err
 	}
+
+	if volume.MountPoint != "" {
+		log.Debugf("syncing filesystems...")
+		if err := util.Sync(); err != nil {
+			return err
+		}
+	}
+	
 	if err := util.CompressDir(volume.Path, snapFile); err != nil {
 		return err
 	}
+
 	volume.Snapshots[id] = Snapshot{
 		Name:        id,
 		CreatedTime: util.Now(),


### PR DESCRIPTION
The VFS and EBS drivers will do a syscall.Sync() before creating a snapshot.  For the EBS driver a new option has been added: ebs.fsfreeze which is false by default.  If set to true, will execute a /sbin/freeze just after the sync() and just before the snapshot is created, and will unfreeze after the snapshot has been created.  
