### PR TITLE
New Driver: ProfitBricks

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ Convoy used Docker volume plugin mechanism to provide persistent volume for Dock
 * Device Mapper
 * Virtual File System(VFS)/Network File System(NFS)
 * Amazon Elastic Block Store(EBS)
+* ProfitBricks
 
 ## Quick Start Guide
 First let's make sure we have Docker 1.8 or above running.
@@ -117,6 +118,12 @@ Make sure you're running on a DigitalOcean Droplet, and that you have the `DO_TO
 sudo convoy daemon --drivers digitalocean
 ```
 
+#### ProfitBricks
+Make sure that you have set the `PROFITBRICKS_USERNAME`, `PROFITBRICKS_PASSWORD`, and `DATACENTER_ID` environment variables before initializing the Convoy daemon. Additional documentation for using the ProfitBricks driver can be found [here](docs/profitbricks.md).
+```
+sudo convoy daemon --drivers profitbricks
+```
+
 ## Volume Commands
 #### Create a Volume
 
@@ -126,6 +133,7 @@ sudo convoy create volume_name
 ```
 * Device Mapper: Default volume size is 100G. `--size` [option](https://github.com/rancher/convoy/blob/master/docs/devicemapper.md#create) is supported.
 * EBS: Default volume size is 4G. `--size` and [some other options](https://github.com/rancher/convoy/blob/master/docs/ebs.md#create) are supported.
+* ProfitBricks: Default volume size is 5G.  `--size` [option](docs/profitbricks.md#create) is supported.
 
 We can also create a volume using the [`docker run`](https://github.com/rancher/convoy/blob/master/docs/docker.md#create-container) command. If the volume does not yet exist, a new volume will be created. Otherwise the existing volume will be used.
 ```
@@ -140,7 +148,7 @@ or
 ```
 sudo docker rm -v <container_name>
 ```
-* NFS, EBS and DigitalOcean: The `-r/--reference` option instructs the `convoy delete` command to only delete the reference to the volume from the current host and leave the underlying files on [NFS server](https://github.com/rancher/convoy/blob/master/docs/vfs.md#delete) or [EBS volume](https://github.com/rancher/convoy/blob/master/docs/ebs.md#delete) unchanged. This is useful when the volume need to be reused later.
+* NFS, EBS, DigitalOcean, and ProfitBricks: The `-r/--reference` option instructs the `convoy delete` command to only delete the reference to the volume from the current host and leave the underlying files on [NFS server](https://github.com/rancher/convoy/blob/master/docs/vfs.md#delete) or [EBS volume](https://github.com/rancher/convoy/blob/master/docs/ebs.md#delete) unchanged. This is useful when the volume need to be reused later.
 * [`docker rm -v`](https://github.com/rancher/convoy/blob/master/docs/docker.md#delete-container) would be treated as `convoy delete` with `-r/--reference`.
 * If you use `--rm` with `docker run`, all the volumes associated with the container would be deleted in the same way as executing `docker rm -v` when exit. See [Docker run reference](https://docs.docker.com/engine/reference/run/) for details.
 
@@ -218,3 +226,5 @@ And of course, [bug fixes](https://github.com/rancher/convoy/issues) are always 
 [Amazon Elastic Block Store](https://github.com/rancher/convoy/blob/master/docs/ebs.md)
 
 [Virtual File System/Network File System](https://github.com/rancher/convoy/blob/master/docs/vfs.md)
+
+[ProfitBricks](docs/profitbricks.md)

--- a/daemon/import_profitbricks.go
+++ b/daemon/import_profitbricks.go
@@ -1,0 +1,6 @@
+package daemon
+
+import (
+	// import ProfitBricks driver for registration
+	_ "github.com/rancher/convoy/profitbricks"
+)

--- a/docs/cli_reference.md
+++ b/docs/cli_reference.md
@@ -41,7 +41,7 @@ OPTIONS:
 ```
 1. ```daemon``` command would start the Convoy daemon.The same Convoy binary would be used to start daemon as well as used as the client to communicate with daemon. In order to use Convoy, user need to setup and start the Convoy daemon first. Convoy daemon would run in the foreground by default. User can use various method e.g. [init-script](https://github.com/fhd/init-script-template) to start Convoy as background daemon.
 2. ```--root``` option would specify Convoy daemon's config root directory. After start Convoy on the host for the first time, it would contains all the information necessary for Convoy to start. After first time of start up, ```convoy daemon``` would automatically load configuration from config root directory. User don't need to specify same configurations anymore.
-3. ```--drivers``` and ```--driver-opts``` can be specified multiple times. ```--drivers``` would be the name of Convoy Driver, and ````--driver-opts``` would be the options for initialize the certain driver. See [```devicemapper```](https://github.com/rancher/convoy/blob/master/docs/devicemapper.md#driver-initialization), ```vfs```, ```ebs``` for driver option details. If there are multiple drivers specified, the first one in the list would be the default driver. See ```convoy create``` for details.
+3. ```--drivers``` and ```--driver-opts``` can be specified multiple times. ```--drivers``` would be the name of Convoy Driver, and ````--driver-opts``` would be the options for initialize the certain driver. See [```devicemapper```](https://github.com/rancher/convoy/blob/master/docs/devicemapper.md#driver-initialization), ```vfs```, ```ebs```, [`profitbricks`](profitbricks.md/#driver-options) for driver option details. If there are multiple drivers specified, the first one in the list would be the default driver. See ```convoy create``` for details.
 
 
 #### info
@@ -71,7 +71,7 @@ OPTIONS:
 ```
 1. ```create``` command would create a volume. ```volume_name``` is optional. If no ```volume_name``` specified, an automatically name would be generated in format of ```volume-xxxxxxxx```, in which last 8 characters would be the first 8 characters of volume's automatical generated UUID. The ```volume_name``` here would be the name user used with Docker.
 2. ```--driver``` option would be used to specify which driver to use if there are more than one driver supported in the setup. Without the option, the default driver(first driver in the list of ```--drivers``` when executing ```daemon``` command) would be used.
-3. ```--size``` option would be used to specify a volume's size if driver supports. Current it's supported by ```devicemapper``` and ```ebs```.
+3. ```--size``` option would be used to specify a volume's size if driver supports. Current it's supported by ```devicemapper```, ```ebs```, and ```profitbricks```.
 4. ```--backup``` option would be used to specify create a volume from existing backup. The backup would be in a format of URL and can be driver specific. See [backup] command for more details.
 5. ```--id```, ```--type```, ```--iops``` are driver specific options. Currenty they're supported by ```ebs```.
 
@@ -87,7 +87,7 @@ OPTIONS:
    --reference, -r	only delete the reference of volume if driver supports
 ```
 1. Volume can be referred by name, UUID, or partial UUID.
-2. ```--reference``` would only delete the reference of volume if driver supports. It provides ability to retain the volume after volume no longer managed by Convoy. Current it's supported by ```vfs``` and ```ebs```. 
+2. ```--reference``` would only delete the reference of volume if driver supports. It provides ability to retain the volume after volume no longer managed by Convoy. Current it's supported by ```vfs```, ```ebs```, and ```profitbricks```.
 
 #### mount
 ```

--- a/docs/profitbricks.md
+++ b/docs/profitbricks.md
@@ -1,0 +1,377 @@
+# Rancher Convoy Driver
+
+## Table of Contents
+
+* [Description](#description)
+* [Getting Started](#getting-started)
+* [Installation](#installation)
+* [Usage](#usage)
+    * [Authentication](#authentication)
+    * [Initialize Convoy Daemon](#initialize-convoy-daemon)
+* [Reference](#reference)
+    * [Volumes](#volumes)
+    * [Snapshots](#snapshots)
+* [Examples](#examples)
+    * [Create New Volume](#create-new-volume)
+    * [Create New Snapshot](#create-new-snapshot)
+    * [Create New Volume from Snapshot](#create-new-volume-from-snapshot)
+    * [Add Existing Volume to Convoy](#add-existing-volume-to-convoy)
+    * [Delete Volume Permanently](#delete-volume-permanently)
+    * [Delete Volume from Convoy Only](#delete-volume-from-convoy-only)
+    * [Delete Snapshot Permanently](#delete-snapshot-permanently)
+    * [Docker Example](#docker-example)
+* [Support](#support)
+* [Testing](#testing)
+* [Contributing](#contributing)
+
+## Description
+Convoy is a Docker volume plugin for a variety of storage back-ends.  Using Convoy with the ProfitBricks backend allows users to persist data across hosts and Docker containers.  ProfitBricks storage volumes can be created and destroyed using Convoy, and users can also create and restore snapshots.  The table in the [Reference](#reference) section is an exhaustive list of all operations that are currently supported by the ProfitBricks Convoy Driver.
+
+## Getting Started
+Before you begin you will need to have signed-up for a ProfitBricks account. The credentials you establish during sign-up will be used to authenticate against the ProfitBricks Cloud API.
+
+Rancher Convoy runs on the Linux operating system.  You will need to provision a ProfitBricks server for each host that you wish to run Convoy.  Each of these hosts will need to have Docker installed and running.
+
+## Installation
+First, let's make sure we have Docker 1.8 or above running:
+```
+docker --version
+```
+If not, install the latest version of Docker as follows:
+```
+curl -sSL https://get.docker.com/ | sh
+```
+Once we've made sure we have Docker running, we can install and configure the Convoy volume plugin as follows:
+```
+wget https://github.com/rancher/convoy/releases/download/v0.5.0/convoy.tar.gz
+tar xvzf convoy.tar.gz
+sudo cp convoy/convoy convoy/convoy-pdata_tools /usr/local/bin/
+sudo mkdir -p /etc/docker/plugins/
+sudo bash -c 'echo "unix:///var/run/convoy/convoy.sock" > /etc/docker/plugins/convoy.spec'
+```
+
+## Usage
+### Authentication
+Before starting the Rancher Convoy daemon, you will need to set a few environment variables first.  These values will be used to communicate with the ProfitBricks REST API.
+
+* `PROFITBRICKS_USERNAME` - User name associated with your ProfitBricks account.
+
+* `PROFITBRICKS_PASSWORD` - Password for the user name specified above.
+
+* `DATACENTER_ID` - UUID of your server's data center.
+
+Example `~/.bash_profile`:
+```
+export PROFITBRICKS_USERNAME="user@example.com"
+export PROFITBRICKS_PASSWORD="Password729!"
+export DATACENTER_ID="a37cff2e-566b-4d8a-94e5-500fc00779de"
+```
+### Initialize Convoy Daemon
+After you've installed Convoy and setup authentication, you are ready to start the Convoy Daemon.  The daemon runs in the foreground, and prints log messages as it performs operations.  You will therefore need to create a separate connection to the host in order to perform operations against the daemon.
+
+Quick Start:
+```
+sudo convoy daemon --drivers profitbricks
+```
+
+With Driver Options:
+```
+sudo convoy daemon --drivers profitbricks --driver-opts profitbricks.defaultvolumesize="10G" --driver-opts profitbricks.defaultvolumetype="SSD"
+```
+
+#### Driver options:
+**`profitbricks.defaultvolumesize`**
+
+`5G` by default. ProfitBricks volumes are `1G` minimum and must be a multiple of `1G`.
+
+**`profitbricks.defaultvolumetype`**
+
+`HDD` by default. This can also be set to `SSD`.
+
+## Reference
+
+### Volumes
+
+Below is a list of volume operations that you can perform.
+
+#### Create
+Create a new volume, create a new volume from snapshot, or add an existing volume to Convoy.
+
+**Convoy Example**: `convoy create <name> --size "10G" --type "SSD"`<br>
+**Docker Example**: `docker run -it -v <name>:/foo --volume-driver=convoy ubuntu`
+
+| Name | Required | Type | Default | Description |
+| --- | :-: | --- | --- | --- |
+| name | no | string | Random UUID | Name of volume. |
+| size | no | string | `"5G"` |  Size of volume in `GB`.  ProfitBricks volumes are `1G` minimum and must be a multiple of `1G`.  Values must be passed with the `"G"` suffix (`--size "10G"`). |
+| type | no | string | `"HDD"` | Type of volume.  Choose from `"HDD"` or `"SSD"`. |
+| id | no | string |  | UUID of an existing ProfitBricks volume. Convoy would use this volume instead of creating a new one. |
+| backup | no | string |  | UUID of an existing ProfitBricks snapshot. Convoy would restore the snapshot into the newly created volume.  If `--size` is specified with `--backup`, then the specified size must be greater than or equal to the snapshot's size. |
+
+* If neither `--id` nor `--backup` are specified, a new volume will be created.
+* If adding an existing volume to Convoy with `--id`, you will need to manually detach the volume from its current server, if necessary.  After detaching the volume, you may then add it to Convoy, and Convoy will attach the volume to its new server.
+* Creating a volume with the `docker run` command will use the default volume size and type.  To specify custom values, create the volume first using `convoy create`, and then refer to the volume by its Convoy name when executing the `docker run` command.
+
+#### Delete
+Delete a Convoy-managed volume.
+
+**Convoy Example**: `convoy delete <name> --reference`<br>
+**Docker Example**: `docker rm -v <container_name>`
+
+| Name | Required | Type | Default | Description |
+| --- | :-: | --- | --- | --- |
+| name | no | string | | Name of volume. |
+| reference | no | bool | `false` | Passing the `--reference` flag will only delete the Convoy reference to the volume, in case the user wants to preserve the volume for future use. Omitting the flag would permanently delete the volume from the ProfitBricks backend. |
+
+* Deleting a volume with `docker rm -v <container_name>` will be treated the same as if you called `convoy delete` with the `--reference` flag.  The volume will be removed from Docker, but not from Convoy, and the volume will not be permanently deleted from the ProfitBricks backend.
+
+#### Inspect
+Returns information about a Convoy-managed volume.
+
+**Convoy Example**: `convoy inspect <name>`
+
+| Name | Required | Type | Default | Description |
+| --- | :-: | --- | --- | --- |
+| name | **yes** | string | | Name of volume. |
+
+```
+root@ubuntu:~# convoy inspect test_volume
+{
+	"Name": "test_volume",
+	"Driver": "profitbricks",
+	"MountPoint": "",
+	"CreatedTime": "2017-03-14 05:54:25 +0000 UTC",
+	"DriverInfo": {
+		"AvailabilityZone": "AUTO",
+		"Device": "/dev/vdb",
+		"Driver": "profitbricks",
+		"Id": "0cbb013f-d839-4b7f-8d33-652cf2648779",
+		"MountPoint": "",
+		"Size": "1073741824",
+		"State": "AVAILABLE",
+		"Type": "HDD",
+		"VolumeCreatedAt": "2017-03-14 05:54:25 +0000 UTC",
+		"VolumeName": "test_volume"
+	},
+	"Snapshots": {}
+}
+```
+* `VolumeName`: Name of volume.
+* `Id`: UUID of volume.
+* `Size`: Size of volume, in bytes.
+* `Type`: Type of volume.  (`HDD` or `SSD`.)
+* `State`: Current state of volume.  (`AVAILABLE` or `BUSY`).
+* `AvailablityZone`: Availability zone of volume. (`AUTO`, `ZONE_1`, `ZONE_2`, `ZONE_3`)
+* `VolumeCreatedAt`: Creation time of volume.
+* `Device`: Block device location of volume. (`/dev/vd_`)
+
+#### List
+Returns a map of all Convoy-managed volumes.
+
+**Convoy Example**: `convoy list`
+
+```
+root@ubuntu:~# convoy list
+{
+	"another_volume": {
+		"Name": "another_volume",
+		"Driver": "profitbricks",
+		"MountPoint": "",
+		"CreatedTime": "2017-03-14 06:05:49 +0000 UTC",
+		"DriverInfo": {
+			"AvailabilityZone": "AUTO",
+			"Device": "/dev/vdc",
+			"Driver": "profitbricks",
+			"Id": "cc5ac2b9-08ef-4dd4-94b3-bccaa4ace242",
+			"MountPoint": "",
+			"Size": "2147483648",
+			"State": "AVAILABLE",
+			"Type": "HDD",
+			"VolumeCreatedAt": "2017-03-14 06:05:49 +0000 UTC",
+			"VolumeName": "another_volume"
+		},
+		"Snapshots": {}
+	},
+	"test_volume": {
+		"Name": "test_volume",
+		"Driver": "profitbricks",
+		"MountPoint": "",
+		"CreatedTime": "2017-03-14 05:54:25 +0000 UTC",
+		"DriverInfo": {
+			"AvailabilityZone": "AUTO",
+			"Device": "/dev/vdb",
+			"Driver": "profitbricks",
+			"Id": "0cbb013f-d839-4b7f-8d33-652cf2648779",
+			"MountPoint": "",
+			"Size": "1073741824",
+			"State": "AVAILABLE",
+			"Type": "HDD",
+			"VolumeCreatedAt": "2017-03-14 05:54:25 +0000 UTC",
+			"VolumeName": "test_volume"
+		},
+		"Snapshots": {}
+	}
+}
+```
+
+### Snapshots
+
+Below is a list of snapshot operations that you can perform.
+
+#### Create
+Create a new snapshot.
+
+**Convoy Example**: `convoy snapshot create <volume_name> --name "test_snapshot"`<br>
+
+| Name | Required | Type | Default | Description |
+| --- | :-: | --- | --- | --- |
+| volume_name | **yes** | string | | Snapshot will be created from this volume. |
+| name | no | string | Random UUID |  Name of snapshot. |
+
+#### Delete
+Delete a Convoy-managed snapshot.
+
+**Convoy Example**: `convoy snapshot delete <name>`<br>
+
+| Name | Required | Type | Default | Description |
+| --- | :-: | --- | --- | --- |
+| name | **yes** | string | |  Name of snapshot. |
+* You will need to manually delete the snapshot from the ProfitBricks backend.
+
+#### Inspect
+Returns information about a Convoy-managed snapshot.
+
+**Convoy Example**: `convoy snapshot inspect <name>`
+
+| Name | Required | Type | Default | Description |
+| --- | :-: | --- | --- | --- |
+| name | **yes** | string | | Name of snapshot. |
+
+```
+root@ubuntu:~# convoy snapshot inspect test_snapshot
+{
+	"Name": "test_snapshot",
+	"VolumeName": "test_volume",
+	"VolumeCreatedAt": "2017-03-14 05:54:25 +0000 UTC",
+	"CreatedTime": "2017-03-14 07:30:38 +0000 UTC",
+	"DriverInfo": {
+		"Description": "Created from \"test_volume\" in Data Center \"Convoy\"",
+		"Driver": "profitbricks",
+		"Id": "dd3378dc-c1dc-4140-be47-27fea3eb5bb1",
+		"Location": "us/las",
+		"Size": "1073741824",
+		"SnapshotCreatedAt": "2017-03-14 07:30:38 +0000 UTC",
+		"SnapshotName": "test_snapshot",
+		"State": "AVAILABLE"
+	}
+}
+```
+* `SnapshotName`: Name of the snapshot.
+* `Id`: UUID of the snapshot.
+* `Description`: Description of the snapshot.
+* `Size`: Size of the snapshot, in bytes.
+* `State`: Current state of the snapshot.  (`AVAILABLE` or `BUSY`).
+* `Location`: Data center location of the snapshot. (`us/las`, `de/fkb`, `de/fra`)
+* `SnapshotCreatedAt`: Creation time of snapshot.
+
+## Examples
+
+#### Create New Volume
+```
+convoy create blank_volume --size "8G" --type "SSD"
+```
+
+#### Create New Snapshot
+```
+convoy snapshot create blank_volume --name "snapshot1"
+```
+
+#### Create New Volume from Snapshot
+```
+convoy create from_snapshot --backup "3f8128b6-4de7-424d-baef-b606dc4aae9a"
+```
+
+#### Add Existing Volume to Convoy
+```
+convoy create existing_volume --id "0cbb013f-d839-4b7f-8d33-652cf2648779"
+```
+
+#### Delete Volume Permanently
+```
+convoy delete blank_volume
+```
+
+#### Delete Volume from Convoy Only
+```
+convoy delete blank_volume --reference
+```
+
+#### Delete Snapshot Permanently
+```
+convoy snapshot delete snapshot1
+```
+
+#### Docker Example
+In this example, we implicitly create a volume named `volume1` with the `docker run` command.  Docker will spin up a container, and we will use `touch` to create a file at `/volume1/foo`.  We then exit the first container.
+
+Spin up a new container using the same volume, `volume1`, and list the contents of `/volume1/foo` to ensure that our data has been preserved from one container to the next.
+
+Creating a volume with the `docker run` command will use the default volume size and type.  To use custom values instead, first you must create the volume using `convoy create`, and then refer to the volume in Docker by its Convoy name.
+```
+root@ubuntu:~# docker run -it -v volume1:/volume1 --volume-driver=convoy ubuntu
+root@c7d73b8733e9:/# touch /volume1/foo
+root@c7d73b8733e9:/# exit
+exit
+root@ubuntu:~# docker run -it -v volume1:/volume1 --volume-driver=convoy ubuntu
+root@4b3a4ef0d35a:/# ls /volume1/foo
+/volume1/foo
+root@4b3a4ef0d35a:/# exit
+exit
+```
+
+## Support
+You are welcome to contact us with questions or comments using the Community section of the [ProfitBricks DevOps Central](https://devops.profitbricks.com/). Please report any feature requests or issues using GitHub issue tracker.
+
+* [Rancher Convoy](https://github.com/rancher/convoy) repository on GitHub.
+* Ask a question or discuss at [ProfitBricks DevOps Central](https://devops.profitbricks.com/community/).
+* Report an [issue here](https://github.com/rancher/convoy/issues).
+
+## Testing
+In order to run unit tests for the ProfitBricks Driver, you will need to ensure that
+a working Golang environment is setup on your Linux machine.  Instructions for setting
+up a Golang environment can be found [here](https://golang.org/doc/install).
+
+**Warning:** Running the test suite will provision resources on your ProfitBricks account.
+
+1. Set [environment variables](#authentication) so that the test suite can authenticate against the ProfitBricks REST API.
+2. Download the source code `go get "github.com/rancher/convoy"`.
+3. Navigate to `$GO_PATH/src/github.com/rancher/convoy/profitbricks/`.
+4. Run `go test`.
+5. If successful, test output should look something like:
+```
+root@ubuntu:~/go_projects/src/github.com/rancher/convoy/profitbricks# go test
+DEBU[0000] Creating blank volume
+DEBU[0007] Creating snapshot
+DEBU[0043] Creating volume from snapshot
+DEBU[0075] Adding pre-existing volume to Convoy
+DEBU[0078] Deleting snapshot
+DEBU[0079] Deleting complex volumes
+DEBU[0080] Creating blank volume
+DEBU[0101] Attaching volume
+DEBU[0117] Checking device path
+DEBU[0117] Testing GET volume
+DEBU[0117] Creating snapshot
+DEBU[0153] Testing GET snapshot
+DEBU[0154] Deleting snapshot
+DEBU[0154] Deleting volume
+OK: 3 passed
+PASS
+ok  	github.com/rancher/convoy/profitbricks	154.839s
+```
+
+## Contributing
+1. Fork the repository. (https://github.com/rancher/convoy/fork)
+2. Create your feature branch. (`git checkout -b my-new-feature`)
+3. Commit your changes. (`git commit -am 'Add some feature'`)
+4. Push to the branch. (`git push origin my-new-feature`)
+5. Create a new Pull Request.

--- a/profitbricks/profitbricks.go
+++ b/profitbricks/profitbricks.go
@@ -1,0 +1,574 @@
+package profitbricks
+
+import(
+  "fmt"
+  "errors"
+  "sync"
+  "path/filepath"
+  "strconv"
+
+  "github.com/rancher/convoy/util"
+  . "github.com/rancher/convoy/convoydriver"
+)
+
+const(
+	DRIVER_NAME        = "profitbricks"
+	DRIVER_CONFIG_FILE = "profitbricks.cfg"
+
+	VOLUME_CFG_PREFIX = "volume_"
+	CFG_PREFIX        = DRIVER_NAME + "_"
+	CFG_SUFFIX       = ".json"
+
+	PB_DEFAULT_VOLUME_SIZE = "profitbricks.defaultvolumesize"
+	PB_DEFAULT_VOLUME_TYPE = "profitbricks.defaultvolumetype"
+	DEFAULT_VOLUME_SIZE = "5G"
+	DEFAULT_VOLUME_TYPE = "HDD"
+
+  BASE_DEVICE_PATH = "/dev/vd"
+  PB_VOLUME_FS = "ext4"
+
+  MOUNTS_DIR    = "mounts"
+
+  GB = int(1073741824)
+)
+
+type Driver struct {
+	mutex  *sync.RWMutex
+	client Client
+	Device
+}
+
+func (d *Driver) Name() string {
+	return DRIVER_NAME
+}
+
+func (d *Driver) blankVolume(name string) *Volume {
+	return &Volume{
+		configPath: d.Root,
+		Name:       name,
+	}
+}
+
+func (d *Driver) remountVolumes() error {
+  volumes, err := util.ListConfigIDs(d.Root, CFG_PREFIX+VOLUME_CFG_PREFIX, CFG_SUFFIX)
+	if err != nil {
+		return err
+	}
+
+	for _, id := range volumes {
+		vol := d.blankVolume(id)
+		if err := util.ObjectLoad(vol); err != nil {
+			return err
+		}
+		if vol.MountPoint == "" {
+			continue
+		}
+
+		req := Request{
+			Name:    id,
+			Options: map[string]string{},
+		}
+		if _, err := d.MountVolume(req); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+type Device struct {
+	Root              string
+	DefaultVolumeSize int
+  DefaultVolumeType string
+}
+
+func (d *Device) ConfigFile() (string, error) {
+	if d.Root == "" {
+		return "", errors.New("BUG: invalid empty device config path")
+	}
+	return filepath.Join(d.Root, DRIVER_CONFIG_FILE), nil
+}
+
+func (v *Volume) ConfigFile() (string, error) {
+	if v.Name == "" {
+		return "", errors.New("empty volume")
+	}
+	if v.configPath == "" {
+		return "", errors.New("empty config path")
+	}
+
+	return filepath.Join(v.configPath, CFG_PREFIX+VOLUME_CFG_PREFIX+v.Name+CFG_SUFFIX), nil
+}
+
+func (v *Volume) GetDevice() (string, error) {
+	return v.Device, nil
+}
+
+func (v *Volume) GetMountOpts() []string {
+	return []string{}
+}
+
+func (v *Volume) GenerateDefaultMountPoint() string {
+	return filepath.Join(v.configPath, MOUNTS_DIR, v.Name)
+}
+
+func init() {
+	Register(DRIVER_NAME, Init)
+}
+
+func Init(root string, config map[string]string) (ConvoyDriver, error) {
+  client, err := InitClient()
+	if err != nil {
+		return nil, err
+	}
+
+  dev := &Device{
+		Root: root,
+	}
+	exists, err := util.ObjectExists(dev)
+	if err != nil {
+		return nil, err
+	}
+
+	if exists {
+		if err := util.ObjectLoad(dev); err != nil {
+			return nil, err
+		}
+	} else {
+		if err := util.MkdirIfNotExists(root); err != nil {
+			return nil, err
+		}
+
+		if config[PB_DEFAULT_VOLUME_SIZE] == "" {
+			config[PB_DEFAULT_VOLUME_SIZE] = DEFAULT_VOLUME_SIZE
+		}
+		size, err := util.ParseSize(config[PB_DEFAULT_VOLUME_SIZE])
+		if err != nil {
+			return nil, err
+		}
+    if config[PB_DEFAULT_VOLUME_TYPE] == "" {
+			config[PB_DEFAULT_VOLUME_TYPE] = DEFAULT_VOLUME_TYPE
+		}
+		volumeType := config[PB_DEFAULT_VOLUME_TYPE]
+		if err := checkVolumeType(volumeType); err != nil {
+      return nil, err
+		}
+
+		dev = &Device{
+			Root:              root,
+			DefaultVolumeSize: int(size),
+      DefaultVolumeType: volumeType,
+		}
+		if err := util.ObjectSave(dev); err != nil {
+			return nil, err
+		}
+	}
+
+	driver := &Driver{
+		Device: *dev,
+		client: client,
+		mutex:  new(sync.RWMutex),
+	}
+
+	if err := driver.remountVolumes(); err != nil {
+		return nil, err
+	}
+	return driver, nil
+}
+
+func checkVolumeType(volumeType string) error {
+	validVolumeType := map[string]bool{
+		"HDD":      true,
+		"SSD":      true,
+	}
+	if !validVolumeType[volumeType] {
+		return fmt.Errorf("Invalid volume type %v", volumeType)
+	}
+	return nil
+}
+
+func (d *Driver) Info() (map[string]string, error) {
+	infos := make(map[string]string)
+	infos["DefaultVolumeSize"] = strconv.FormatInt(int64(d.DefaultVolumeSize), 10)
+	infos["DefaultVolumeType"] = d.DefaultVolumeType
+	return infos, nil
+}
+
+func (d *Driver) VolumeOps() (VolumeOperations, error) {
+	return d, nil
+}
+
+func (d *Driver) CreateVolume(req Request) error {
+  d.mutex.Lock()
+	defer d.mutex.Unlock()
+
+	id := req.Name
+	opt := req.Options
+	vol := d.blankVolume(id)
+
+	exists, err := util.ObjectExists(vol)
+	if err != nil {
+		return err
+	}
+	if exists {
+		return fmt.Errorf("volume %s already exists", id)
+	}
+
+  var (
+    snapshotId string
+    volumeId string
+    size   int
+    deviceSuffix string
+		format bool
+	)
+  snapshotId = opt[OPT_BACKUP_URL]
+  volumeId = opt[OPT_VOLUME_DRIVER_ID]
+  size, err = d.getSize(opt, d.DefaultVolumeSize)
+  if err != nil {
+    return err
+  }
+
+  if volumeId != "" {
+    _, err := d.client.CreateVolume(CreateVolumeParams{
+      Name: id,
+      Size: (size / GB),
+      Id: volumeId,
+      SnapshotId: snapshotId,
+    })
+    if err != nil {
+      return err
+    }
+
+    volume, err := d.client.AttachVolume(volumeId)
+    if err != nil {
+  		return err
+  	}
+    size = (volume.Size * GB)
+    deviceSuffix = d.client.GetDeviceSuffix(volume.DeviceNumber)
+  } else {
+    volumeType := opt[OPT_VOLUME_TYPE]
+    if volumeType != "" {
+      err = checkVolumeType(volumeType)
+      if err != nil {
+        volumeType = d.DefaultVolumeType
+      }
+    } else {
+      volumeType = d.DefaultVolumeType
+    }
+
+  	volume, err := d.client.CreateVolume(CreateVolumeParams{
+      Name: id,
+      Size: (size / GB),
+      Type: volumeType,
+      SnapshotId: snapshotId,
+    })
+    if err != nil {
+      return err
+    }
+
+    if volume, err = d.client.AttachVolume(volume.Id); err != nil {
+  		return err
+  	}
+    volumeId = volume.Id
+    size = (volume.Size * GB)
+    deviceSuffix = d.client.GetDeviceSuffix(volume.DeviceNumber)
+    format = true
+  }
+
+  vol.Name = id
+  vol.Id = volumeId
+	vol.Device = BASE_DEVICE_PATH + deviceSuffix
+	vol.Size = size
+  vol.Snapshots = make(map[string]Snapshot)
+
+	if format {
+    if _, err := util.Execute("mkfs", []string{"-t", PB_VOLUME_FS, vol.Device}); err != nil {
+			return err
+		}
+	}
+	return util.ObjectSave(vol)
+}
+
+func (d *Driver) getSize(opts map[string]string, defaultVolumeSize int) (int, error) {
+	size := opts[OPT_SIZE]
+	if size == "" || size == "0" {
+		size = strconv.FormatInt(int64(defaultVolumeSize), 10)
+	}
+  parsedSize, err := util.ParseSize(size)
+  if err != nil {
+    return 0, err
+  }
+  return int(parsedSize), nil
+}
+
+func (d *Driver) DeleteVolume(req Request) error {
+	d.mutex.Lock()
+	defer d.mutex.Unlock()
+
+	id := req.Name
+	opts := req.Options
+
+	vol := d.blankVolume(id)
+	if err := util.ObjectLoad(vol); err != nil {
+		return err
+	}
+
+	reference, _ := strconv.ParseBool(opts[OPT_REFERENCE_ONLY])
+  if !reference {
+    err := d.client.DeleteVolume(vol.Id)
+    if err != nil {
+      return err
+    }
+  }
+
+	return util.ObjectDelete(vol)
+}
+
+func (d *Driver) GetVolumeInfo(name string) (map[string]string, error) {
+	d.mutex.Lock()
+	defer d.mutex.Unlock()
+
+  vol := d.blankVolume(name)
+	if err := util.ObjectLoad(vol); err != nil {
+		return nil, err
+	}
+
+  volume, err := d.client.GetVolume(vol.Id)
+	if err != nil {
+		return nil, err
+	}
+  size := strconv.FormatInt(int64((volume.Size * GB)), 10)
+
+	info := map[string]string{
+		"Device": vol.Device,
+		"MountPoint": vol.MountPoint,
+		"Id": vol.Id,
+		OPT_VOLUME_NAME: name,
+		"Size": size,
+    "Type": volume.Type,
+    "State": volume.State,
+    "AvailabilityZone": volume.AvailabilityZone,
+    OPT_VOLUME_CREATED_TIME: volume.CreationTime,
+	}
+	return info, nil
+}
+
+func (d *Driver) MountVolume(req Request) (string, error) {
+	id := req.Name
+	opts := req.Options
+
+	vol := d.blankVolume(id)
+	if err := util.ObjectLoad(vol); err != nil {
+		return "", err
+	}
+
+	mountPoint, err := util.VolumeMount(vol, opts[OPT_MOUNT_POINT], false)
+	if err != nil {
+		return "", err
+	}
+
+	if err := util.ObjectSave(vol); err != nil {
+		return "", err
+	}
+
+	return mountPoint, nil
+}
+
+func (d *Driver) UmountVolume(req Request) error {
+	id := req.Name
+
+	vol := d.blankVolume(id)
+	if err := util.ObjectLoad(vol); err != nil {
+		return err
+	}
+
+	if err := util.VolumeUmount(vol); err != nil {
+		return err
+	}
+
+	return util.ObjectSave(vol)
+}
+
+func (d *Driver) MountPoint(req Request) (string, error) {
+	id := req.Name
+
+	vol := d.blankVolume(id)
+	if err := util.ObjectLoad(vol); err != nil {
+		return "", err
+	}
+
+	return vol.MountPoint, nil
+}
+
+func (d *Driver) ListVolume(opts map[string]string) (map[string]map[string]string, error) {
+	volumes, err := util.ListConfigIDs(d.Root, CFG_PREFIX+VOLUME_CFG_PREFIX, CFG_SUFFIX)
+	if err != nil {
+		return nil, err
+	}
+	ret := make(map[string]map[string]string)
+	for _, id := range volumes {
+		ret[id], err = d.GetVolumeInfo(id)
+		if err != nil {
+			return nil, err
+		}
+	}
+	return ret, nil
+}
+
+func (d *Driver) SnapshotOps() (SnapshotOperations, error) {
+	return d, nil
+}
+
+func (d *Driver) CreateSnapshot(req Request) error {
+	d.mutex.Lock()
+	defer d.mutex.Unlock()
+
+	id := req.Name
+	volumeName, err := util.GetFieldFromOpts(OPT_VOLUME_NAME, req.Options)
+	if err != nil {
+		return err
+	}
+
+	vol := d.blankVolume(volumeName)
+	if err := util.ObjectLoad(vol); err != nil {
+		return err
+	}
+
+	_, exists := vol.Snapshots[id]
+	if exists {
+		return fmt.Errorf("This volume already has a snapshot with UUID %s", id)
+	}
+
+  snapshot, err := d.client.CreateSnapshot(vol.Id, id)
+  if err != nil {
+    return err
+  }
+
+	snapshot = Snapshot{
+		Name: id,
+		Id: snapshot.Id,
+    Description: snapshot.Description,
+    Size: snapshot.Size,
+    State: snapshot.State,
+    Location: snapshot.Location,
+	}
+
+  vol.Snapshots[id] = snapshot
+	return util.ObjectSave(vol)
+}
+
+func (d *Driver) DeleteSnapshot(req Request) error {
+	d.mutex.Lock()
+	defer d.mutex.Unlock()
+
+	id := req.Name
+	volumeName, err := util.GetFieldFromOpts(OPT_VOLUME_NAME, req.Options)
+	if err != nil {
+		return err
+	}
+
+  vol := d.blankVolume(volumeName)
+	if err := util.ObjectLoad(vol); err != nil {
+		return err
+	}
+
+  _, exists := vol.Snapshots[id]
+  if !exists {
+    return fmt.Errorf("Snapshot %s does not exist for volume %s.", id, volumeName)
+  }
+
+	delete(vol.Snapshots, id)
+	return util.ObjectSave(vol)
+}
+
+func (d *Driver) GetSnapshotInfo(req Request) (map[string]string, error) {
+	d.mutex.Lock()
+	defer d.mutex.Unlock()
+
+	id := req.Name
+	volumeName, err := util.GetFieldFromOpts(OPT_VOLUME_NAME, req.Options)
+	if err != nil {
+		return nil, err
+	}
+
+  vol := d.blankVolume(volumeName)
+	if err := util.ObjectLoad(vol); err != nil {
+		return nil, err
+	}
+
+  snapshot, exists := vol.Snapshots[id]
+  if exists {
+    snapshot, err = d.client.GetSnapshot(snapshot.Id)
+    if err != nil {
+      return nil, err
+    }
+
+  	info := map[string]string{
+      OPT_SNAPSHOT_NAME: id,
+  		"Id": snapshot.Id,
+      "Description": snapshot.Description,
+      OPT_SIZE: strconv.FormatInt(int64((snapshot.Size * GB)), 10),
+      "State": snapshot.State,
+      "Location": snapshot.Location,
+      OPT_SNAPSHOT_CREATED_TIME: snapshot.CreationTime,
+  	}
+    return info, nil
+  } else {
+    return nil, fmt.Errorf("Snapshot %s does not exist for volume %s.", id, volumeName)
+  }
+}
+
+func (d *Driver) ListSnapshot(opts map[string]string) (map[string]map[string]string, error) {
+	d.mutex.Lock()
+	defer d.mutex.Unlock()
+
+	var (
+		volumeIDs []string
+		err       error
+	)
+	snapshots := make(map[string]map[string]string)
+	specifiedVolumeID, _ := util.GetFieldFromOpts(OPT_VOLUME_NAME, opts)
+	if specifiedVolumeID != "" {
+		volumeIDs = []string{
+			specifiedVolumeID,
+		}
+	} else {
+		volumeIDs, err = util.ListConfigIDs(d.Root, CFG_PREFIX+VOLUME_CFG_PREFIX, CFG_SUFFIX)
+		if err != nil {
+			return nil, err
+		}
+	}
+	for _, volumeID := range volumeIDs {
+		volume := d.blankVolume(volumeID)
+		if err := util.ObjectLoad(volume); err != nil {
+			return nil, err
+		}
+		for snapshotID := range volume.Snapshots {
+      snapshot, err := d.client.GetSnapshot(volume.Snapshots[snapshotID].Id)
+			if err != nil {
+				return nil, err
+			}
+
+      info := map[string]string{
+        OPT_SNAPSHOT_NAME: snapshot.Name,
+        "VolumeName": volumeID,
+    		"Id": snapshot.Id,
+        "Description": snapshot.Description,
+        OPT_SIZE: strconv.FormatInt(int64((snapshot.Size * GB)), 10),
+        "State": snapshot.State,
+        "Location": snapshot.Location,
+        OPT_SNAPSHOT_CREATED_TIME: snapshot.CreationTime,
+      }
+
+      snapshots[snapshotID] = info
+		}
+	}
+	return snapshots, nil
+}
+
+// There is no concept of "Backups" at ProfitBricks.
+// Snapshots are available across all data centers in the same location.
+// Any new volume can be restored from an existing snapshot.
+func (d *Driver) BackupOps() (BackupOperations, error) {
+	return nil, errors.New("Not implemented")
+}

--- a/profitbricks/profitbricks_service.go
+++ b/profitbricks/profitbricks_service.go
@@ -1,0 +1,341 @@
+package profitbricks
+
+import(
+  "os"
+  "fmt"
+  "errors"
+  "time"
+  "strings"
+
+  "github.com/Sirupsen/logrus"
+  "github.com/dselans/dmidecode"
+  sdk "github.com/profitbricks/profitbricks-sdk-go"
+)
+
+const(
+  DEFAULT_DEPTH = "5"
+  DEFAULT_LICENSE_TYPE = "OTHER"
+  TIMEOUT = 120
+)
+
+var(
+  log = logrus.WithFields(logrus.Fields{"pkg": "profitbricks"})
+  datacenterId string
+  serverId string
+)
+
+type Client struct {}
+
+type Volume struct {
+  Name string
+  Id string
+  Device string
+  MountPoint string
+  Size int
+  configPath string
+  Type string
+  State string
+  AvailabilityZone string
+  CreationTime string
+  DeviceNumber int
+  Snapshots  map[string]Snapshot
+}
+
+type Snapshot struct {
+  Name string
+  Id string
+  Description string
+  Size int
+  State string
+  Location string
+  CreationTime string
+}
+
+type CreateVolumeParams struct {
+  Id string
+  Name string
+  Size int
+  Type string
+  SnapshotId string
+}
+
+func InitClient() (Client, error) {
+  user, password, err := getCredentials()
+  if err != nil {
+    return Client{}, err
+  }
+  sdk.SetAuth(user, password)
+  sdk.SetDepth(DEFAULT_DEPTH)
+
+  datacenterId, err = getDatacenterId()
+  if err != nil {
+    return Client{}, err
+  }
+  serverId, err = getServerId()
+  if err != nil {
+    return Client{}, err
+  }
+  return Client{}, nil
+}
+
+func getCredentials() (string, string, error) {
+	user := os.Getenv("PROFITBRICKS_USERNAME")
+  password := os.Getenv("PROFITBRICKS_PASSWORD")
+	if user == "" {
+		return "", "", errors.New("No user found. Please set the PROFITBRICKS_USERNAME environment variable.")
+	}
+  if password == "" {
+		return "", "", errors.New("No password found. Please set the PROFITBRICKS_PASSWORD environment variable.")
+	}
+	return user, password, nil
+}
+
+func getDatacenterId() (string, error) {
+  datacenterId := os.Getenv("DATACENTER_ID")
+  if datacenterId == "" {
+		return "", errors.New("No datacenter ID found. Please set the DATACENTER_ID environment variable.")
+	}
+  return datacenterId, nil
+}
+
+func getServerId() (string, error) {
+  dmi := dmidecode.New()
+  if err := dmi.Run(); err != nil {
+      return "", fmt.Errorf("Unable to get dmidecode information. Error: %v\n", err)
+  }
+
+  systemInfo, err := dmi.SearchByName("System Information")
+  if err != nil {
+    return "", fmt.Errorf("Unable to get System Information. Error: %v\n", err)
+  }
+
+	uuid := string(systemInfo["UUID"])
+  return strings.ToLower(uuid), nil
+}
+
+func checkResponse(statusCode int, response, action string) (error) {
+  if statusCode > 299 {
+    logError(statusCode, response, action)
+    return errors.New("Bad response from ProfitBricks API.")
+  }
+  return nil
+}
+
+func logError(statusCode int, response, action string) {
+  log.WithFields(logrus.Fields{
+    "status_code": statusCode,
+    "response": response,
+  }).Errorf("%s call failed.", action)
+}
+
+func waitFor(path string) (bool, error) {
+  counter := 0
+  for counter <= TIMEOUT {
+    request, err := getRequestStatus(path)
+    if err != nil {
+      return false, err
+    }
+    if request.Metadata.Status == "DONE" {
+      return true, nil
+    }
+    time.Sleep(time.Second * 1)
+    counter++
+  }
+  return false, fmt.Errorf("Timed out checking the status of request %s", path)
+}
+
+func getRequestStatus(path string) (sdk.RequestStatus, error) {
+  status := sdk.GetRequestStatus(path)
+  err := checkResponse(status.StatusCode, status.Response, "Get Request status")
+  if err != nil {
+    return sdk.RequestStatus{}, err
+  }
+  return status, nil
+}
+
+func (c *Client) GetDeviceSuffix(deviceNumber int) (string) {
+  if deviceNumber == 0 {
+    return ""
+  } else {
+    return string('a' - 1 + deviceNumber)
+  }
+}
+
+func (c *Client) CreateVolume(params CreateVolumeParams) (Volume, error) {
+  if params.Id == "" && params.SnapshotId == "" {
+    volume := sdk.CreateVolume(datacenterId, sdk.Volume{
+      Properties: sdk.VolumeProperties{
+        Name: params.Name,
+        Size: params.Size,
+        Type: params.Type,
+        LicenceType: DEFAULT_LICENSE_TYPE,
+      },
+    })
+    err := checkResponse(volume.StatusCode, volume.Response, "Create volume")
+    if err != nil {
+      return Volume{}, errors.New(fmt.Sprintf("Creation of volume: %s failed.", params.Name))
+    }
+    if success, err := waitFor(volume.Headers.Get("Location")); success {
+      return toVolume(volume), nil
+    } else {
+      return Volume{}, errors.New(fmt.Sprintf("Creation of volume: %s failed. Reason: %s", params.Name, err))
+    }
+  } else if params.Id != "" && params.SnapshotId == "" {
+    volume, err := getVolume(params.Id)
+    if err != nil {
+      return Volume{}, err
+    }
+
+    volumeSize := volume.Size
+    if params.Size > volumeSize {
+      volumeSize = params.Size
+    }
+
+    updatedVolume := sdk.PatchVolume(datacenterId, params.Id, sdk.VolumeProperties{
+      Name: params.Name,
+      Size: volumeSize,
+    })
+    err = checkResponse(updatedVolume.StatusCode, updatedVolume.Response, "Patch volume")
+    if err != nil {
+      return Volume{}, fmt.Errorf("Failed to PATCH volume with UUID %s. Reason: %s", params.Id, err)
+    }
+    if success, err := waitFor(updatedVolume.Headers.Get("Location")); success {
+      return toVolume(updatedVolume), nil
+    } else {
+      return Volume{}, err
+    }
+  } else if params.Id == "" && params.SnapshotId != "" {
+    snapshot, err := getSnapshot(params.SnapshotId)
+    if err != nil {
+      return Volume{}, errors.New(fmt.Sprintf("Failed to retrieve snapshot: ", params.SnapshotId))
+    }
+    size := snapshot.Size
+    if params.Size > size {
+      size = params.Size
+    }
+    volume := sdk.CreateVolume(datacenterId, sdk.Volume{
+      Properties: sdk.VolumeProperties{
+        Name: params.Name,
+        Size: size,
+        Type: params.Type,
+        Image: params.SnapshotId,
+      },
+    })
+    err = checkResponse(volume.StatusCode, volume.Response, "Create volume")
+    if err != nil {
+      return Volume{}, errors.New(fmt.Sprintf("Creation of volume: %s failed.", params.Name))
+    }
+    if success, err := waitFor(volume.Headers.Get("Location")); success {
+      return toVolume(volume), nil
+    } else {
+      return Volume{}, errors.New(fmt.Sprintf("Creation of volume: %s failed. Reason: %s", params.Name, err))
+    }
+  } else if params.Id != "" && params.SnapshotId != "" {
+    return Volume{}, errors.New("Cannot restore snapshot to existing volume. You can either add an existing volume to Convoy, or create a new volume from snapshot.")
+  } else {
+    return Volume{}, errors.New("Bad argument combination for the CreateVolume request.")
+  }
+}
+
+func (c *Client) DeleteVolume(volumeId string) (error) {
+  response := sdk.DeleteVolume(datacenterId, volumeId)
+  err := checkResponse(response.StatusCode, "", "Delete volume")
+  if err != nil {
+    return errors.New(fmt.Sprint("Failed to permanently delete volume: ", volumeId))
+  }
+  return nil
+}
+
+func (c *Client) AttachVolume(volumeId string) (Volume, error) {
+  response := sdk.AttachVolume(datacenterId, serverId, volumeId)
+  err := checkResponse(response.StatusCode, response.Response, "Attach volume")
+  if err != nil {
+    return Volume{}, err
+  }
+  if success, err := waitFor(response.Headers.Get("Location")); success {
+    volume, err := getVolume(volumeId)
+    if err != nil {
+      return Volume{}, err
+    }
+    return volume, nil
+  } else {
+    return Volume{}, err
+  }
+}
+
+func (c *Client) GetVolume(volumeId string) (Volume, error) {
+  return getVolume(volumeId)
+}
+
+func getVolume(volumeId string) (Volume, error) {
+  volume := sdk.GetVolume(datacenterId, volumeId)
+  err := checkResponse(volume.StatusCode, volume.Response, "Get volume")
+  if err != nil {
+    return Volume{}, err
+  }
+  return toVolume(volume), nil
+}
+
+func (c *Client) CreateSnapshot(volumeId, name string) (Snapshot, error) {
+  snapshot := sdk.CreateSnapshot(datacenterId, volumeId, name)
+  err := checkResponse(snapshot.StatusCode, snapshot.Response, "Create snapshot")
+  if err != nil {
+    return Snapshot{}, errors.New(fmt.Sprint("Failed to create snapshot: ", name))
+  }
+  if success, err := waitFor(snapshot.Headers.Get("Location")); success {
+    provisionedSnapshot, err := getSnapshot(snapshot.Id) // Refresh snapshot info
+    if err != nil {
+      return Snapshot{}, err
+    }
+    return provisionedSnapshot, nil
+  } else {
+    return Snapshot{}, err
+  }
+}
+
+func (c *Client) DeleteSnapshot(snapshotId string) (error) {
+  response := sdk.DeleteSnapshot(snapshotId)
+  err := checkResponse(response.StatusCode, "", "Delete snapshot")
+  if err != nil {
+    return errors.New(fmt.Sprint("Failed to permanently delete snapshot: ", snapshotId))
+  }
+  return nil
+}
+
+func (c *Client) GetSnapshot(snapshotId string) (Snapshot, error) {
+  return getSnapshot(snapshotId)
+}
+
+func getSnapshot(snapshotId string) (Snapshot, error) {
+  snapshot := sdk.GetSnapshot(snapshotId)
+  err := checkResponse(snapshot.StatusCode, snapshot.Response, "Get snapshot")
+  if err != nil {
+    return Snapshot{}, err
+  }
+  return toSnapshot(snapshot), nil
+}
+
+func toVolume(volume sdk.Volume) (Volume) {
+  return Volume{
+    Name: volume.Properties.Name,
+    Id: volume.Id,
+    Type: volume.Properties.Type,
+    Size: volume.Properties.Size,
+    State: volume.Metadata.State,
+    AvailabilityZone: volume.Properties.AvailabilityZone,
+    CreationTime: volume.Metadata.CreatedDate.String(),
+    DeviceNumber: int(volume.Properties.DeviceNumber),
+  }
+}
+
+func toSnapshot(snapshot sdk.Snapshot) (Snapshot) {
+  return Snapshot{
+    Name: snapshot.Properties.Name,
+    Id: snapshot.Id,
+    Description: snapshot.Properties.Description,
+    Size: snapshot.Properties.Size,
+    State: snapshot.Metadata.State,
+    Location: snapshot.Properties.Location,
+    CreationTime: snapshot.Metadata.CreatedDate.String(),
+  }
+}

--- a/profitbricks/profitbricks_service.go
+++ b/profitbricks/profitbricks_service.go
@@ -1,341 +1,341 @@
 package profitbricks
 
-import(
-  "os"
-  "fmt"
-  "errors"
-  "time"
-  "strings"
+import (
+	"errors"
+	"fmt"
+	"os"
+	"strings"
+	"time"
 
-  "github.com/Sirupsen/logrus"
-  "github.com/dselans/dmidecode"
-  sdk "github.com/profitbricks/profitbricks-sdk-go"
+	"github.com/Sirupsen/logrus"
+	"github.com/dselans/dmidecode"
+	sdk "github.com/profitbricks/profitbricks-sdk-go"
 )
 
-const(
-  DEFAULT_DEPTH = "5"
-  DEFAULT_LICENSE_TYPE = "OTHER"
-  TIMEOUT = 120
+const (
+	DEFAULT_DEPTH        = "5"
+	DEFAULT_LICENSE_TYPE = "OTHER"
+	TIMEOUT              = 120
 )
 
-var(
-  log = logrus.WithFields(logrus.Fields{"pkg": "profitbricks"})
-  datacenterId string
-  serverId string
+var (
+	log          = logrus.WithFields(logrus.Fields{"pkg": "profitbricks"})
+	datacenterId string
+	serverId     string
 )
 
-type Client struct {}
+type Client struct{}
 
 type Volume struct {
-  Name string
-  Id string
-  Device string
-  MountPoint string
-  Size int
-  configPath string
-  Type string
-  State string
-  AvailabilityZone string
-  CreationTime string
-  DeviceNumber int
-  Snapshots  map[string]Snapshot
+	Name             string
+	Id               string
+	Device           string
+	MountPoint       string
+	Size             int
+	configPath       string
+	Type             string
+	State            string
+	AvailabilityZone string
+	CreationTime     string
+	DeviceNumber     int
+	Snapshots        map[string]Snapshot
 }
 
 type Snapshot struct {
-  Name string
-  Id string
-  Description string
-  Size int
-  State string
-  Location string
-  CreationTime string
+	Name         string
+	Id           string
+	Description  string
+	Size         int
+	State        string
+	Location     string
+	CreationTime string
 }
 
 type CreateVolumeParams struct {
-  Id string
-  Name string
-  Size int
-  Type string
-  SnapshotId string
+	Id         string
+	Name       string
+	Size       int
+	Type       string
+	SnapshotId string
 }
 
 func InitClient() (Client, error) {
-  user, password, err := getCredentials()
-  if err != nil {
-    return Client{}, err
-  }
-  sdk.SetAuth(user, password)
-  sdk.SetDepth(DEFAULT_DEPTH)
+	user, password, err := getCredentials()
+	if err != nil {
+		return Client{}, err
+	}
+	sdk.SetAuth(user, password)
+	sdk.SetDepth(DEFAULT_DEPTH)
 
-  datacenterId, err = getDatacenterId()
-  if err != nil {
-    return Client{}, err
-  }
-  serverId, err = getServerId()
-  if err != nil {
-    return Client{}, err
-  }
-  return Client{}, nil
+	datacenterId, err = getDatacenterId()
+	if err != nil {
+		return Client{}, err
+	}
+	serverId, err = getServerId()
+	if err != nil {
+		return Client{}, err
+	}
+	return Client{}, nil
 }
 
 func getCredentials() (string, string, error) {
 	user := os.Getenv("PROFITBRICKS_USERNAME")
-  password := os.Getenv("PROFITBRICKS_PASSWORD")
+	password := os.Getenv("PROFITBRICKS_PASSWORD")
 	if user == "" {
 		return "", "", errors.New("No user found. Please set the PROFITBRICKS_USERNAME environment variable.")
 	}
-  if password == "" {
+	if password == "" {
 		return "", "", errors.New("No password found. Please set the PROFITBRICKS_PASSWORD environment variable.")
 	}
 	return user, password, nil
 }
 
 func getDatacenterId() (string, error) {
-  datacenterId := os.Getenv("DATACENTER_ID")
-  if datacenterId == "" {
+	datacenterId := os.Getenv("DATACENTER_ID")
+	if datacenterId == "" {
 		return "", errors.New("No datacenter ID found. Please set the DATACENTER_ID environment variable.")
 	}
-  return datacenterId, nil
+	return datacenterId, nil
 }
 
 func getServerId() (string, error) {
-  dmi := dmidecode.New()
-  if err := dmi.Run(); err != nil {
-      return "", fmt.Errorf("Unable to get dmidecode information. Error: %v\n", err)
-  }
+	dmi := dmidecode.New()
+	if err := dmi.Run(); err != nil {
+		return "", fmt.Errorf("Unable to get dmidecode information. Error: %v\n", err)
+	}
 
-  systemInfo, err := dmi.SearchByName("System Information")
-  if err != nil {
-    return "", fmt.Errorf("Unable to get System Information. Error: %v\n", err)
-  }
+	systemInfo, err := dmi.SearchByName("System Information")
+	if err != nil {
+		return "", fmt.Errorf("Unable to get System Information. Error: %v\n", err)
+	}
 
 	uuid := string(systemInfo["UUID"])
-  return strings.ToLower(uuid), nil
+	return strings.ToLower(uuid), nil
 }
 
-func checkResponse(statusCode int, response, action string) (error) {
-  if statusCode > 299 {
-    logError(statusCode, response, action)
-    return errors.New("Bad response from ProfitBricks API.")
-  }
-  return nil
+func checkResponse(statusCode int, response, action string) error {
+	if statusCode > 299 {
+		logError(statusCode, response, action)
+		return errors.New("Bad response from ProfitBricks API.")
+	}
+	return nil
 }
 
 func logError(statusCode int, response, action string) {
-  log.WithFields(logrus.Fields{
-    "status_code": statusCode,
-    "response": response,
-  }).Errorf("%s call failed.", action)
+	log.WithFields(logrus.Fields{
+		"status_code": statusCode,
+		"response":    response,
+	}).Errorf("%s call failed.", action)
 }
 
 func waitFor(path string) (bool, error) {
-  counter := 0
-  for counter <= TIMEOUT {
-    request, err := getRequestStatus(path)
-    if err != nil {
-      return false, err
-    }
-    if request.Metadata.Status == "DONE" {
-      return true, nil
-    }
-    time.Sleep(time.Second * 1)
-    counter++
-  }
-  return false, fmt.Errorf("Timed out checking the status of request %s", path)
+	counter := 0
+	for counter <= TIMEOUT {
+		request, err := getRequestStatus(path)
+		if err != nil {
+			return false, err
+		}
+		if request.Metadata.Status == "DONE" {
+			return true, nil
+		}
+		time.Sleep(time.Second * 1)
+		counter++
+	}
+	return false, fmt.Errorf("Timed out checking the status of request %s", path)
 }
 
 func getRequestStatus(path string) (sdk.RequestStatus, error) {
-  status := sdk.GetRequestStatus(path)
-  err := checkResponse(status.StatusCode, status.Response, "Get Request status")
-  if err != nil {
-    return sdk.RequestStatus{}, err
-  }
-  return status, nil
+	status := sdk.GetRequestStatus(path)
+	err := checkResponse(status.StatusCode, status.Response, "Get Request status")
+	if err != nil {
+		return sdk.RequestStatus{}, err
+	}
+	return status, nil
 }
 
-func (c *Client) GetDeviceSuffix(deviceNumber int) (string) {
-  if deviceNumber == 0 {
-    return ""
-  } else {
-    return string('a' - 1 + deviceNumber)
-  }
+func (c *Client) GetDeviceSuffix(deviceNumber int) string {
+	if deviceNumber == 0 {
+		return ""
+	} else {
+		return string('a' - 1 + deviceNumber)
+	}
 }
 
 func (c *Client) CreateVolume(params CreateVolumeParams) (Volume, error) {
-  if params.Id == "" && params.SnapshotId == "" {
-    volume := sdk.CreateVolume(datacenterId, sdk.Volume{
-      Properties: sdk.VolumeProperties{
-        Name: params.Name,
-        Size: params.Size,
-        Type: params.Type,
-        LicenceType: DEFAULT_LICENSE_TYPE,
-      },
-    })
-    err := checkResponse(volume.StatusCode, volume.Response, "Create volume")
-    if err != nil {
-      return Volume{}, errors.New(fmt.Sprintf("Creation of volume: %s failed.", params.Name))
-    }
-    if success, err := waitFor(volume.Headers.Get("Location")); success {
-      return toVolume(volume), nil
-    } else {
-      return Volume{}, errors.New(fmt.Sprintf("Creation of volume: %s failed. Reason: %s", params.Name, err))
-    }
-  } else if params.Id != "" && params.SnapshotId == "" {
-    volume, err := getVolume(params.Id)
-    if err != nil {
-      return Volume{}, err
-    }
+	if params.Id == "" && params.SnapshotId == "" {
+		volume := sdk.CreateVolume(datacenterId, sdk.Volume{
+			Properties: sdk.VolumeProperties{
+				Name:        params.Name,
+				Size:        params.Size,
+				Type:        params.Type,
+				LicenceType: DEFAULT_LICENSE_TYPE,
+			},
+		})
+		err := checkResponse(volume.StatusCode, volume.Response, "Create volume")
+		if err != nil {
+			return Volume{}, errors.New(fmt.Sprintf("Creation of volume: %s failed.", params.Name))
+		}
+		if success, err := waitFor(volume.Headers.Get("Location")); success {
+			return toVolume(volume), nil
+		} else {
+			return Volume{}, errors.New(fmt.Sprintf("Creation of volume: %s failed. Reason: %s", params.Name, err))
+		}
+	} else if params.Id != "" && params.SnapshotId == "" {
+		volume, err := getVolume(params.Id)
+		if err != nil {
+			return Volume{}, err
+		}
 
-    volumeSize := volume.Size
-    if params.Size > volumeSize {
-      volumeSize = params.Size
-    }
+		volumeSize := volume.Size
+		if params.Size > volumeSize {
+			volumeSize = params.Size
+		}
 
-    updatedVolume := sdk.PatchVolume(datacenterId, params.Id, sdk.VolumeProperties{
-      Name: params.Name,
-      Size: volumeSize,
-    })
-    err = checkResponse(updatedVolume.StatusCode, updatedVolume.Response, "Patch volume")
-    if err != nil {
-      return Volume{}, fmt.Errorf("Failed to PATCH volume with UUID %s. Reason: %s", params.Id, err)
-    }
-    if success, err := waitFor(updatedVolume.Headers.Get("Location")); success {
-      return toVolume(updatedVolume), nil
-    } else {
-      return Volume{}, err
-    }
-  } else if params.Id == "" && params.SnapshotId != "" {
-    snapshot, err := getSnapshot(params.SnapshotId)
-    if err != nil {
-      return Volume{}, errors.New(fmt.Sprintf("Failed to retrieve snapshot: ", params.SnapshotId))
-    }
-    size := snapshot.Size
-    if params.Size > size {
-      size = params.Size
-    }
-    volume := sdk.CreateVolume(datacenterId, sdk.Volume{
-      Properties: sdk.VolumeProperties{
-        Name: params.Name,
-        Size: size,
-        Type: params.Type,
-        Image: params.SnapshotId,
-      },
-    })
-    err = checkResponse(volume.StatusCode, volume.Response, "Create volume")
-    if err != nil {
-      return Volume{}, errors.New(fmt.Sprintf("Creation of volume: %s failed.", params.Name))
-    }
-    if success, err := waitFor(volume.Headers.Get("Location")); success {
-      return toVolume(volume), nil
-    } else {
-      return Volume{}, errors.New(fmt.Sprintf("Creation of volume: %s failed. Reason: %s", params.Name, err))
-    }
-  } else if params.Id != "" && params.SnapshotId != "" {
-    return Volume{}, errors.New("Cannot restore snapshot to existing volume. You can either add an existing volume to Convoy, or create a new volume from snapshot.")
-  } else {
-    return Volume{}, errors.New("Bad argument combination for the CreateVolume request.")
-  }
+		updatedVolume := sdk.PatchVolume(datacenterId, params.Id, sdk.VolumeProperties{
+			Name: params.Name,
+			Size: volumeSize,
+		})
+		err = checkResponse(updatedVolume.StatusCode, updatedVolume.Response, "Patch volume")
+		if err != nil {
+			return Volume{}, fmt.Errorf("Failed to PATCH volume with UUID %s. Reason: %s", params.Id, err)
+		}
+		if success, err := waitFor(updatedVolume.Headers.Get("Location")); success {
+			return toVolume(updatedVolume), nil
+		} else {
+			return Volume{}, err
+		}
+	} else if params.Id == "" && params.SnapshotId != "" {
+		snapshot, err := getSnapshot(params.SnapshotId)
+		if err != nil {
+			return Volume{}, errors.New(fmt.Sprintf("Failed to retrieve snapshot: ", params.SnapshotId))
+		}
+		size := snapshot.Size
+		if params.Size > size {
+			size = params.Size
+		}
+		volume := sdk.CreateVolume(datacenterId, sdk.Volume{
+			Properties: sdk.VolumeProperties{
+				Name:  params.Name,
+				Size:  size,
+				Type:  params.Type,
+				Image: params.SnapshotId,
+			},
+		})
+		err = checkResponse(volume.StatusCode, volume.Response, "Create volume")
+		if err != nil {
+			return Volume{}, errors.New(fmt.Sprintf("Creation of volume: %s failed.", params.Name))
+		}
+		if success, err := waitFor(volume.Headers.Get("Location")); success {
+			return toVolume(volume), nil
+		} else {
+			return Volume{}, errors.New(fmt.Sprintf("Creation of volume: %s failed. Reason: %s", params.Name, err))
+		}
+	} else if params.Id != "" && params.SnapshotId != "" {
+		return Volume{}, errors.New("Cannot restore snapshot to existing volume. You can either add an existing volume to Convoy, or create a new volume from snapshot.")
+	} else {
+		return Volume{}, errors.New("Bad argument combination for the CreateVolume request.")
+	}
 }
 
-func (c *Client) DeleteVolume(volumeId string) (error) {
-  response := sdk.DeleteVolume(datacenterId, volumeId)
-  err := checkResponse(response.StatusCode, "", "Delete volume")
-  if err != nil {
-    return errors.New(fmt.Sprint("Failed to permanently delete volume: ", volumeId))
-  }
-  return nil
+func (c *Client) DeleteVolume(volumeId string) error {
+	response := sdk.DeleteVolume(datacenterId, volumeId)
+	err := checkResponse(response.StatusCode, "", "Delete volume")
+	if err != nil {
+		return errors.New(fmt.Sprint("Failed to permanently delete volume: ", volumeId))
+	}
+	return nil
 }
 
 func (c *Client) AttachVolume(volumeId string) (Volume, error) {
-  response := sdk.AttachVolume(datacenterId, serverId, volumeId)
-  err := checkResponse(response.StatusCode, response.Response, "Attach volume")
-  if err != nil {
-    return Volume{}, err
-  }
-  if success, err := waitFor(response.Headers.Get("Location")); success {
-    volume, err := getVolume(volumeId)
-    if err != nil {
-      return Volume{}, err
-    }
-    return volume, nil
-  } else {
-    return Volume{}, err
-  }
+	response := sdk.AttachVolume(datacenterId, serverId, volumeId)
+	err := checkResponse(response.StatusCode, response.Response, "Attach volume")
+	if err != nil {
+		return Volume{}, err
+	}
+	if success, err := waitFor(response.Headers.Get("Location")); success {
+		volume, err := getVolume(volumeId)
+		if err != nil {
+			return Volume{}, err
+		}
+		return volume, nil
+	} else {
+		return Volume{}, err
+	}
 }
 
 func (c *Client) GetVolume(volumeId string) (Volume, error) {
-  return getVolume(volumeId)
+	return getVolume(volumeId)
 }
 
 func getVolume(volumeId string) (Volume, error) {
-  volume := sdk.GetVolume(datacenterId, volumeId)
-  err := checkResponse(volume.StatusCode, volume.Response, "Get volume")
-  if err != nil {
-    return Volume{}, err
-  }
-  return toVolume(volume), nil
+	volume := sdk.GetVolume(datacenterId, volumeId)
+	err := checkResponse(volume.StatusCode, volume.Response, "Get volume")
+	if err != nil {
+		return Volume{}, err
+	}
+	return toVolume(volume), nil
 }
 
 func (c *Client) CreateSnapshot(volumeId, name string) (Snapshot, error) {
-  snapshot := sdk.CreateSnapshot(datacenterId, volumeId, name)
-  err := checkResponse(snapshot.StatusCode, snapshot.Response, "Create snapshot")
-  if err != nil {
-    return Snapshot{}, errors.New(fmt.Sprint("Failed to create snapshot: ", name))
-  }
-  if success, err := waitFor(snapshot.Headers.Get("Location")); success {
-    provisionedSnapshot, err := getSnapshot(snapshot.Id) // Refresh snapshot info
-    if err != nil {
-      return Snapshot{}, err
-    }
-    return provisionedSnapshot, nil
-  } else {
-    return Snapshot{}, err
-  }
+	snapshot := sdk.CreateSnapshot(datacenterId, volumeId, name)
+	err := checkResponse(snapshot.StatusCode, snapshot.Response, "Create snapshot")
+	if err != nil {
+		return Snapshot{}, errors.New(fmt.Sprint("Failed to create snapshot: ", name))
+	}
+	if success, err := waitFor(snapshot.Headers.Get("Location")); success {
+		provisionedSnapshot, err := getSnapshot(snapshot.Id) // Refresh snapshot info
+		if err != nil {
+			return Snapshot{}, err
+		}
+		return provisionedSnapshot, nil
+	} else {
+		return Snapshot{}, err
+	}
 }
 
-func (c *Client) DeleteSnapshot(snapshotId string) (error) {
-  response := sdk.DeleteSnapshot(snapshotId)
-  err := checkResponse(response.StatusCode, "", "Delete snapshot")
-  if err != nil {
-    return errors.New(fmt.Sprint("Failed to permanently delete snapshot: ", snapshotId))
-  }
-  return nil
+func (c *Client) DeleteSnapshot(snapshotId string) error {
+	response := sdk.DeleteSnapshot(snapshotId)
+	err := checkResponse(response.StatusCode, "", "Delete snapshot")
+	if err != nil {
+		return errors.New(fmt.Sprint("Failed to permanently delete snapshot: ", snapshotId))
+	}
+	return nil
 }
 
 func (c *Client) GetSnapshot(snapshotId string) (Snapshot, error) {
-  return getSnapshot(snapshotId)
+	return getSnapshot(snapshotId)
 }
 
 func getSnapshot(snapshotId string) (Snapshot, error) {
-  snapshot := sdk.GetSnapshot(snapshotId)
-  err := checkResponse(snapshot.StatusCode, snapshot.Response, "Get snapshot")
-  if err != nil {
-    return Snapshot{}, err
-  }
-  return toSnapshot(snapshot), nil
+	snapshot := sdk.GetSnapshot(snapshotId)
+	err := checkResponse(snapshot.StatusCode, snapshot.Response, "Get snapshot")
+	if err != nil {
+		return Snapshot{}, err
+	}
+	return toSnapshot(snapshot), nil
 }
 
-func toVolume(volume sdk.Volume) (Volume) {
-  return Volume{
-    Name: volume.Properties.Name,
-    Id: volume.Id,
-    Type: volume.Properties.Type,
-    Size: volume.Properties.Size,
-    State: volume.Metadata.State,
-    AvailabilityZone: volume.Properties.AvailabilityZone,
-    CreationTime: volume.Metadata.CreatedDate.String(),
-    DeviceNumber: int(volume.Properties.DeviceNumber),
-  }
+func toVolume(volume sdk.Volume) Volume {
+	return Volume{
+		Name:             volume.Properties.Name,
+		Id:               volume.Id,
+		Type:             volume.Properties.Type,
+		Size:             volume.Properties.Size,
+		State:            volume.Metadata.State,
+		AvailabilityZone: volume.Properties.AvailabilityZone,
+		CreationTime:     volume.Metadata.CreatedDate.String(),
+		DeviceNumber:     int(volume.Properties.DeviceNumber),
+	}
 }
 
-func toSnapshot(snapshot sdk.Snapshot) (Snapshot) {
-  return Snapshot{
-    Name: snapshot.Properties.Name,
-    Id: snapshot.Id,
-    Description: snapshot.Properties.Description,
-    Size: snapshot.Properties.Size,
-    State: snapshot.Metadata.State,
-    Location: snapshot.Properties.Location,
-    CreationTime: snapshot.Metadata.CreatedDate.String(),
-  }
+func toSnapshot(snapshot sdk.Snapshot) Snapshot {
+	return Snapshot{
+		Name:         snapshot.Properties.Name,
+		Id:           snapshot.Id,
+		Description:  snapshot.Properties.Description,
+		Size:         snapshot.Properties.Size,
+		State:        snapshot.Metadata.State,
+		Location:     snapshot.Properties.Location,
+		CreationTime: snapshot.Metadata.CreatedDate.String(),
+	}
 }

--- a/profitbricks/profitbricks_test.go
+++ b/profitbricks/profitbricks_test.go
@@ -29,57 +29,57 @@ func (s *TestSuite) TestVolumeAndSnapshot(c *C) {
 	svc, err := InitClient()
 	c.Assert(err, IsNil)
 
-  // Simple server creation here.  More complex test cases in TestComplexVolume
-  logrus.Debug("Creating blank volume")
-  var (
-    volumeName = "test_volume"
-    volumeSize = int(1)
-    volumeType = "HDD"
-  )
-  volumeParams := CreateVolumeParams{
-    Name: volumeName,
-    Size: volumeSize,
-    Type: volumeType,
-  }
-  volume, err := svc.CreateVolume(volumeParams)
+	// Simple server creation here.  More complex test cases in TestComplexVolume
+	logrus.Debug("Creating blank volume")
+	var (
+		volumeName = "test_volume"
+		volumeSize = int(1)
+		volumeType = "HDD"
+	)
+	volumeParams := CreateVolumeParams{
+		Name: volumeName,
+		Size: volumeSize,
+		Type: volumeType,
+	}
+	volume, err := svc.CreateVolume(volumeParams)
 	c.Assert(err, IsNil)
 	c.Assert(volume.Name, Equals, volumeName)
-  c.Assert(volume.Size, Equals, volumeSize)
-  c.Assert(volume.Type, Equals, volumeType)
+	c.Assert(volume.Size, Equals, volumeSize)
+	c.Assert(volume.Type, Equals, volumeType)
 
 	logrus.Debug("Attaching volume")
 	volume, err = svc.AttachVolume(volume.Id)
 	c.Assert(err, IsNil)
-  c.Assert(volume.DeviceNumber, Not(Equals), IsNil)
+	c.Assert(volume.DeviceNumber, Not(Equals), IsNil)
 
-  logrus.Debug("Checking device path")
-  deviceSuffix := svc.GetDeviceSuffix(volume.DeviceNumber)
-  devicePath := BASE_DEVICE_PATH + deviceSuffix
+	logrus.Debug("Checking device path")
+	deviceSuffix := svc.GetDeviceSuffix(volume.DeviceNumber)
+	devicePath := BASE_DEVICE_PATH + deviceSuffix
 	stat1, err := os.Stat(devicePath)
 	c.Assert(err, IsNil)
 	c.Assert(stat1.Mode()&os.ModeDevice != 0, Equals, true)
 
-  logrus.Debug("Testing GET volume")
-  volume, err = svc.GetVolume(volume.Id)
-  c.Assert(err, IsNil)
-  c.Assert(volume.Name, Equals, volumeName)
-  c.Assert(volume.Size, Equals, volumeSize)
-  c.Assert(volume.Type, Equals, volumeType)
+	logrus.Debug("Testing GET volume")
+	volume, err = svc.GetVolume(volume.Id)
+	c.Assert(err, IsNil)
+	c.Assert(volume.Name, Equals, volumeName)
+	c.Assert(volume.Size, Equals, volumeSize)
+	c.Assert(volume.Type, Equals, volumeType)
 
-  logrus.Debug("Creating snapshot")
-  snapshotName := "test_snapshot"
-  snapshot, err := svc.CreateSnapshot(volume.Id, snapshotName)
-  c.Assert(err, IsNil)
-  c.Assert(snapshot.Name, Equals, snapshotName)
-  c.Assert(snapshot.Size, Equals, volume.Size)
+	logrus.Debug("Creating snapshot")
+	snapshotName := "test_snapshot"
+	snapshot, err := svc.CreateSnapshot(volume.Id, snapshotName)
+	c.Assert(err, IsNil)
+	c.Assert(snapshot.Name, Equals, snapshotName)
+	c.Assert(snapshot.Size, Equals, volume.Size)
 
-  logrus.Debug("Testing GET snapshot")
-  snapshot, err = svc.GetSnapshot(snapshot.Id)
-  c.Assert(err, IsNil)
-  c.Assert(snapshot.Name, Equals, snapshotName)
-  c.Assert(snapshot.Size, Equals, volume.Size)
+	logrus.Debug("Testing GET snapshot")
+	snapshot, err = svc.GetSnapshot(snapshot.Id)
+	c.Assert(err, IsNil)
+	c.Assert(snapshot.Name, Equals, snapshotName)
+	c.Assert(snapshot.Size, Equals, volume.Size)
 
-  logrus.Debug("Deleting snapshot")
+	logrus.Debug("Deleting snapshot")
 	err = svc.DeleteSnapshot(snapshot.Id)
 	c.Assert(err, IsNil)
 
@@ -92,63 +92,63 @@ func (s *TestSuite) TestComplexVolume(c *C) {
 	svc, err := InitClient()
 	c.Assert(err, IsNil)
 
-  logrus.Debug("Creating blank volume")
-  var (
-    volumeName = "blank_volume"
-    volumeSize = int(1)
-    volumeType = "HDD"
-  )
-  volumeParams := CreateVolumeParams{
-    Name: volumeName,
-    Size: volumeSize,
-    Type: volumeType,
-  }
-  blankVolume, err := svc.CreateVolume(volumeParams)
+	logrus.Debug("Creating blank volume")
+	var (
+		volumeName = "blank_volume"
+		volumeSize = int(1)
+		volumeType = "HDD"
+	)
+	volumeParams := CreateVolumeParams{
+		Name: volumeName,
+		Size: volumeSize,
+		Type: volumeType,
+	}
+	blankVolume, err := svc.CreateVolume(volumeParams)
 	c.Assert(err, IsNil)
 	c.Assert(blankVolume.Name, Equals, volumeName)
-  c.Assert(blankVolume.Size, Equals, volumeSize)
-  c.Assert(blankVolume.Type, Equals, volumeType)
+	c.Assert(blankVolume.Size, Equals, volumeSize)
+	c.Assert(blankVolume.Type, Equals, volumeType)
 
-  logrus.Debug("Creating snapshot")
-  snapshotName := "test_snapshot"
-  snapshot, err := svc.CreateSnapshot(blankVolume.Id, snapshotName)
-  c.Assert(err, IsNil)
-  c.Assert(snapshot.Name, Equals, snapshotName)
-  c.Assert(snapshot.Size, Equals, blankVolume.Size)
+	logrus.Debug("Creating snapshot")
+	snapshotName := "test_snapshot"
+	snapshot, err := svc.CreateSnapshot(blankVolume.Id, snapshotName)
+	c.Assert(err, IsNil)
+	c.Assert(snapshot.Name, Equals, snapshotName)
+	c.Assert(snapshot.Size, Equals, blankVolume.Size)
 
-  logrus.Debug("Creating volume from snapshot")
-  volumeName = "from_snapshot"
-  volumeParams = CreateVolumeParams{
-    Name: volumeName,
-    Size: volumeSize,
-    Type: volumeType,
-    SnapshotId: snapshot.Id,
-  }
-  fromSnapshot, err := svc.CreateVolume(volumeParams)
+	logrus.Debug("Creating volume from snapshot")
+	volumeName = "from_snapshot"
+	volumeParams = CreateVolumeParams{
+		Name:       volumeName,
+		Size:       volumeSize,
+		Type:       volumeType,
+		SnapshotId: snapshot.Id,
+	}
+	fromSnapshot, err := svc.CreateVolume(volumeParams)
 	c.Assert(err, IsNil)
 	c.Assert(fromSnapshot.Name, Equals, volumeName)
-  c.Assert(fromSnapshot.Size, Equals, volumeSize)
-  c.Assert(fromSnapshot.Type, Equals, volumeType)
+	c.Assert(fromSnapshot.Size, Equals, volumeSize)
+	c.Assert(fromSnapshot.Type, Equals, volumeType)
 
-  logrus.Debug("Adding pre-existing volume to Convoy")
-  volumeName = "existing_volume"
-  volumeParams = CreateVolumeParams{
-    Name: volumeName,
-    Id: blankVolume.Id,
-  }
-  existingVolume, err := svc.CreateVolume(volumeParams)
+	logrus.Debug("Adding pre-existing volume to Convoy")
+	volumeName = "existing_volume"
+	volumeParams = CreateVolumeParams{
+		Name: volumeName,
+		Id:   blankVolume.Id,
+	}
+	existingVolume, err := svc.CreateVolume(volumeParams)
 	c.Assert(err, IsNil)
 	c.Assert(existingVolume.Name, Equals, volumeName)
-  c.Assert(existingVolume.Size, Equals, volumeSize)
-  c.Assert(existingVolume.Type, Equals, volumeType)
+	c.Assert(existingVolume.Size, Equals, volumeSize)
+	c.Assert(existingVolume.Type, Equals, volumeType)
 
-  logrus.Debug("Deleting snapshot")
+	logrus.Debug("Deleting snapshot")
 	err = svc.DeleteSnapshot(snapshot.Id)
 	c.Assert(err, IsNil)
 
-  logrus.Debug("Deleting complex volumes")
+	logrus.Debug("Deleting complex volumes")
 	err = svc.DeleteVolume(fromSnapshot.Id)
 	c.Assert(err, IsNil)
-  err = svc.DeleteVolume(existingVolume.Id)
+	err = svc.DeleteVolume(existingVolume.Id)
 	c.Assert(err, IsNil)
 }

--- a/profitbricks/profitbricks_test.go
+++ b/profitbricks/profitbricks_test.go
@@ -1,0 +1,154 @@
+package profitbricks
+
+import (
+	"os"
+	"testing"
+
+	"github.com/Sirupsen/logrus"
+
+	. "gopkg.in/check.v1"
+)
+
+func Test(t *testing.T) { TestingT(t) }
+
+type TestSuite struct{}
+
+var _ = Suite(&TestSuite{})
+
+func (s *TestSuite) SetUpSuite(c *C) {
+	logrus.SetLevel(logrus.DebugLevel)
+	logrus.SetOutput(os.Stderr)
+}
+
+func (s *TestSuite) TestProfitBricksMetadata(c *C) {
+	_, err := InitClient()
+	c.Assert(err, IsNil)
+}
+
+func (s *TestSuite) TestVolumeAndSnapshot(c *C) {
+	svc, err := InitClient()
+	c.Assert(err, IsNil)
+
+  // Simple server creation here.  More complex test cases in TestComplexVolume
+  logrus.Debug("Creating blank volume")
+  var (
+    volumeName = "test_volume"
+    volumeSize = int(1)
+    volumeType = "HDD"
+  )
+  volumeParams := CreateVolumeParams{
+    Name: volumeName,
+    Size: volumeSize,
+    Type: volumeType,
+  }
+  volume, err := svc.CreateVolume(volumeParams)
+	c.Assert(err, IsNil)
+	c.Assert(volume.Name, Equals, volumeName)
+  c.Assert(volume.Size, Equals, volumeSize)
+  c.Assert(volume.Type, Equals, volumeType)
+
+	logrus.Debug("Attaching volume")
+	volume, err = svc.AttachVolume(volume.Id)
+	c.Assert(err, IsNil)
+  c.Assert(volume.DeviceNumber, Not(Equals), IsNil)
+
+  logrus.Debug("Checking device path")
+  deviceSuffix := svc.GetDeviceSuffix(volume.DeviceNumber)
+  devicePath := BASE_DEVICE_PATH + deviceSuffix
+	stat1, err := os.Stat(devicePath)
+	c.Assert(err, IsNil)
+	c.Assert(stat1.Mode()&os.ModeDevice != 0, Equals, true)
+
+  logrus.Debug("Testing GET volume")
+  volume, err = svc.GetVolume(volume.Id)
+  c.Assert(err, IsNil)
+  c.Assert(volume.Name, Equals, volumeName)
+  c.Assert(volume.Size, Equals, volumeSize)
+  c.Assert(volume.Type, Equals, volumeType)
+
+  logrus.Debug("Creating snapshot")
+  snapshotName := "test_snapshot"
+  snapshot, err := svc.CreateSnapshot(volume.Id, snapshotName)
+  c.Assert(err, IsNil)
+  c.Assert(snapshot.Name, Equals, snapshotName)
+  c.Assert(snapshot.Size, Equals, volume.Size)
+
+  logrus.Debug("Testing GET snapshot")
+  snapshot, err = svc.GetSnapshot(snapshot.Id)
+  c.Assert(err, IsNil)
+  c.Assert(snapshot.Name, Equals, snapshotName)
+  c.Assert(snapshot.Size, Equals, volume.Size)
+
+  logrus.Debug("Deleting snapshot")
+	err = svc.DeleteSnapshot(snapshot.Id)
+	c.Assert(err, IsNil)
+
+	logrus.Debug("Deleting volume")
+	err = svc.DeleteVolume(volume.Id)
+	c.Assert(err, IsNil)
+}
+
+func (s *TestSuite) TestComplexVolume(c *C) {
+	svc, err := InitClient()
+	c.Assert(err, IsNil)
+
+  logrus.Debug("Creating blank volume")
+  var (
+    volumeName = "blank_volume"
+    volumeSize = int(1)
+    volumeType = "HDD"
+  )
+  volumeParams := CreateVolumeParams{
+    Name: volumeName,
+    Size: volumeSize,
+    Type: volumeType,
+  }
+  blankVolume, err := svc.CreateVolume(volumeParams)
+	c.Assert(err, IsNil)
+	c.Assert(blankVolume.Name, Equals, volumeName)
+  c.Assert(blankVolume.Size, Equals, volumeSize)
+  c.Assert(blankVolume.Type, Equals, volumeType)
+
+  logrus.Debug("Creating snapshot")
+  snapshotName := "test_snapshot"
+  snapshot, err := svc.CreateSnapshot(blankVolume.Id, snapshotName)
+  c.Assert(err, IsNil)
+  c.Assert(snapshot.Name, Equals, snapshotName)
+  c.Assert(snapshot.Size, Equals, blankVolume.Size)
+
+  logrus.Debug("Creating volume from snapshot")
+  volumeName = "from_snapshot"
+  volumeParams = CreateVolumeParams{
+    Name: volumeName,
+    Size: volumeSize,
+    Type: volumeType,
+    SnapshotId: snapshot.Id,
+  }
+  fromSnapshot, err := svc.CreateVolume(volumeParams)
+	c.Assert(err, IsNil)
+	c.Assert(fromSnapshot.Name, Equals, volumeName)
+  c.Assert(fromSnapshot.Size, Equals, volumeSize)
+  c.Assert(fromSnapshot.Type, Equals, volumeType)
+
+  logrus.Debug("Adding pre-existing volume to Convoy")
+  volumeName = "existing_volume"
+  volumeParams = CreateVolumeParams{
+    Name: volumeName,
+    Id: blankVolume.Id,
+  }
+  existingVolume, err := svc.CreateVolume(volumeParams)
+	c.Assert(err, IsNil)
+	c.Assert(existingVolume.Name, Equals, volumeName)
+  c.Assert(existingVolume.Size, Equals, volumeSize)
+  c.Assert(existingVolume.Type, Equals, volumeType)
+
+  logrus.Debug("Deleting snapshot")
+	err = svc.DeleteSnapshot(snapshot.Id)
+	c.Assert(err, IsNil)
+
+  logrus.Debug("Deleting complex volumes")
+	err = svc.DeleteVolume(fromSnapshot.Id)
+	c.Assert(err, IsNil)
+  err = svc.DeleteVolume(existingVolume.Id)
+	c.Assert(err, IsNil)
+}

--- a/trash.yml
+++ b/trash.yml
@@ -84,3 +84,9 @@ import:
 
 - package: golang.org/x/oauth2
   version: 3c3a985cb79f52a3190fbc056984415ca6763d01
+
+- package: github.com/profitbricks/profitbricks-sdk-go
+  version: bede198c761c0333994050a3f11a56469b22938c
+
+- package: github.com/dselans/dmidecode
+  version: 08eabb429b4ad1353e56dd634048b05d811ba062

--- a/vendor/github.com/dselans/dmidecode/README.md
+++ b/vendor/github.com/dselans/dmidecode/README.md
@@ -1,0 +1,40 @@
+dmidecode
+=========
+
+`dmidecode` is a Go library that parses the output of the `dmidecode` command
+and makes it accessible via a simple map data structure.
+
+In addition, the library exposes a couple of convenience methods for quicker record lookups.
+
+## Usage
+
+```go
+import (
+    dmidecode "github.com/dselans/dmidecode"
+)
+
+dmi := dmidecode.New()
+
+if err := dmi.Run(); err != nil {
+    fmt.Printf("Unable to get dmidecode information. Error: %v\n", err)
+}
+
+// You can search by record name
+byNameData, byNameErr := dmi.SearchByName("System Information")
+
+// or you can also search by record type
+byTypeData, byTypeErr := dmi.SearchByType(1)
+
+// or you can just access the data directly
+for handle, record := range dmi.Data {
+    fmt.Println("Checking record:", handle)
+    for k, v := range record {
+        fmt.Printf("Key: %v Val: %v\n", k, v)
+    }
+}
+```
+
+## Note
+Record elements which contain an array/list, are stored as strings separated by 2 tabs (same as in `dmidecode` output). This may change in the future, but for the time being it's simple and quick.
+
+Note that `dmidecode` requires root privs to run as the binary reads `/dev/mem`.

--- a/vendor/github.com/dselans/dmidecode/dmidecode.go
+++ b/vendor/github.com/dselans/dmidecode/dmidecode.go
@@ -1,0 +1,179 @@
+package dmidecode
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"regexp"
+	"strconv"
+	"strings"
+)
+
+type DMI struct {
+	Data map[string]map[string]string
+}
+
+func New() *DMI {
+	dmi := &DMI{}
+	dmi.Data = make(map[string]map[string]string)
+	return dmi
+}
+
+// Wrapper for FindBin, ExecCmd, ParseDmidecode
+func (d *DMI) Run() error {
+	bin, findErr := d.FindBin("dmidecode")
+	if findErr != nil {
+		return findErr
+	}
+
+	cmdOutput, cmdErr := d.ExecDmidecode(bin)
+	if cmdErr != nil {
+		return cmdErr
+	}
+
+	if err := d.ParseDmidecode(cmdOutput); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (d *DMI) FindBin(binary string) (string, error) {
+	locations := []string{"/sbin", "/usr/sbin", "/usr/local/sbin"}
+
+	for _, path := range locations {
+		lookup := path + "/" + binary
+		fileInfo, err := os.Stat(path + "/" + binary)
+
+		if err != nil {
+			continue
+		}
+
+		if !fileInfo.IsDir() {
+			return lookup, nil
+		}
+	}
+
+	return "", errors.New(fmt.Sprintf("Unable to find the '%v' binary", binary))
+}
+
+func (d *DMI) ExecDmidecode(binary string) (string, error) {
+	cmd := exec.Command(binary)
+
+	output, err := cmd.Output()
+
+	if err != nil {
+		return "", err
+	}
+
+	return string(output), nil
+}
+
+// Gross; maybe there is a cleaner way to get this done via multiline regex
+func (d *DMI) ParseDmidecode(output string) error {
+	// Each record is separated by double newlines
+	splitOutput := strings.Split(output, "\n\n")
+
+	for _, record := range splitOutput {
+		recordElements := strings.Split(record, "\n")
+
+		// Entries with less than 3 lines are incomplete/inactive; skip them
+		if len(recordElements) < 3 {
+			continue
+		}
+
+		handleRegex, _ := regexp.Compile("^Handle\\s+(.+),\\s+DMI\\s+type\\s+(\\d+),\\s+(\\d+)\\s+bytes$")
+		handleData := handleRegex.FindStringSubmatch(recordElements[0])
+
+		if len(handleData) == 0 {
+			continue
+		}
+
+		dmiHandle := handleData[1]
+
+		d.Data[dmiHandle] = make(map[string]string)
+		d.Data[dmiHandle]["DMIType"] = handleData[2]
+		d.Data[dmiHandle]["DMISize"] = handleData[3]
+
+		// Okay, we know 2nd line == name
+		d.Data[dmiHandle]["DMIName"] = recordElements[1]
+
+		inBlockElement := ""
+		inBlockList := ""
+
+		// Loop over the rest of the record, gathering values
+		for i := 2; i < len(recordElements); i++ {
+			// Check whether we are inside a \t\t block
+			if inBlockElement != "" {
+				inBlockRegex, _ := regexp.Compile("^\\t\\t(.+)$")
+				inBlockData := inBlockRegex.FindStringSubmatch(recordElements[i])
+
+				if len(inBlockData) > 0 {
+					if len(inBlockList) == 0 {
+						inBlockList = inBlockData[1]
+					} else {
+						inBlockList = inBlockList + "\t\t" + inBlockData[1]
+					}
+					d.Data[dmiHandle][inBlockElement] = inBlockList
+					continue
+				} else {
+					// We are out of the \t\t block; reset it again, and let
+					// the parsing continue
+					inBlockElement = ""
+				}
+			}
+
+			recordRegex, _ := regexp.Compile("\\t(.+):\\s+(.+)$")
+			recordData := recordRegex.FindStringSubmatch(recordElements[i])
+
+			// Is this the line containing handle identifier, type, size?
+			if len(recordData) > 0 {
+				d.Data[dmiHandle][recordData[1]] = recordData[2]
+				continue
+			}
+
+			// Didn't match regular entry, maybe an array of data?
+			recordRegex2, _ := regexp.Compile("\\t(.+):$")
+			recordData2 := recordRegex2.FindStringSubmatch(recordElements[i])
+
+			if len(recordData2) > 0 {
+				// This is an array of data - let the loop know we are inside
+				// an array block
+				inBlockElement = recordData2[1]
+				continue
+			}
+		}
+	}
+
+	if len(d.Data) == 0 {
+		return errors.New("Unable to parse 'dmidecode' output")
+	}
+
+	return nil
+}
+
+// Generic map lookup method
+func (d *DMI) GenericSearchBy(param, value string) (map[string]string, error) {
+	if len(d.Data) == 0 {
+		return nil, errors.New("DMI data is empty; make sure to .Run() first")
+	}
+
+	for _, v := range d.Data {
+		if v[param] == value {
+			return v, nil
+		}
+	}
+
+	return make(map[string]string), nil
+}
+
+// Search for a specific DMI record by name
+func (d *DMI) SearchByName(name string) (map[string]string, error) {
+	return d.GenericSearchBy("DMIName", name)
+}
+
+// Search for a specific DMI record by its type
+func (d *DMI) SearchByType(id int) (map[string]string, error) {
+	return d.GenericSearchBy("DMIType", strconv.Itoa(id))
+}

--- a/vendor/github.com/dselans/dmidecode/dmidecode_test.go
+++ b/vendor/github.com/dselans/dmidecode/dmidecode_test.go
@@ -1,0 +1,156 @@
+package dmidecode
+
+import (
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+const (
+	fakeBinary string = "time4soup"
+	testDir    string = "test_data"
+)
+
+func TestFindBin(t *testing.T) {
+	dmi := New()
+
+	if _, err := dmi.FindBin("time4soup"); err == nil {
+		t.Error("Should not be able to find obscure binary")
+	}
+
+	bin, findErr := dmi.FindBin("dmidecode")
+	if findErr != nil {
+		t.Errorf("Should be able to find dmidecode. Error: %v", findErr)
+	}
+
+	_, statErr := os.Stat(bin)
+
+	if statErr != nil {
+		t.Errorf("Should be able to lookup found file. Error: %v", statErr)
+	}
+}
+
+func TestExecDmidecode(t *testing.T) {
+	dmi := New()
+
+	if _, err := dmi.ExecDmidecode("/bin/" + fakeBinary); err == nil {
+		t.Errorf("Should get an error trying to execute a fake binary. Error: %v", err)
+	}
+
+	bin, findErr := dmi.FindBin("dmidecode")
+	if findErr != nil {
+		t.Errorf("Should be able to find binary. Error: %v", findErr)
+	}
+
+	output, execErr := dmi.ExecDmidecode(bin)
+
+	if execErr != nil {
+		t.Errorf("Should not get errors executing '%v'. Error: %v", bin, execErr)
+	}
+
+	if len(output) == 0 {
+		t.Errorf("Output should not be empty")
+	}
+}
+
+func TestParseDmidecode(t *testing.T) {
+	dmi := New()
+
+	bin, findErr := dmi.FindBin("dmidecode")
+	if findErr != nil {
+		t.Errorf("Should be able to find binary. Error: %v", findErr)
+	}
+
+	output, execErr := dmi.ExecDmidecode(bin)
+
+	if execErr != nil {
+		t.Errorf("Should not get errors executing '%v'. Error: %v", bin, execErr)
+	}
+
+	if err := dmi.ParseDmidecode(output); err != nil {
+		t.Error("Should not receive an error after parsing dmidecode output")
+	}
+
+	if len(dmi.Data) == 0 {
+		t.Error("Parsed data structure should have more than 0 entries")
+	}
+
+	files, globErr := filepath.Glob(testDir + "/*")
+	if globErr != nil {
+		t.Errorf("Should not receive errors during '%v' glob. Error: %v", testDir, globErr)
+	}
+
+	for _, file := range files {
+		// Let's clear it out, each iteration (just in case)
+		dmi.Data = make(map[string]map[string]string)
+
+		data, readErr := ioutil.ReadFile(file)
+		if readErr != nil {
+			t.Errorf("Should not receive errors while reading contents of '%v'. Error: %v", file, readErr)
+		}
+
+		if err := dmi.ParseDmidecode(string(data)); err != nil {
+			t.Errorf("Should not get errors while parsing '%v'. Error:", file, err)
+		}
+
+		if len(dmi.Data) == 0 {
+			t.Errorf("Data length should be larger than 0 after reading '%v'", file)
+		}
+	}
+}
+
+func TestRun(t *testing.T) {
+	dmi := New()
+
+	if err := dmi.Run(); err != nil {
+		t.Errorf("Run() should not return any errors. Error: %v", err)
+	}
+}
+
+func TestSearchBy(t *testing.T) {
+	dmi := New()
+
+	if _, err := dmi.SearchByName("System Information"); err == nil {
+		t.Error("Should have received an error when Search ran prior to .Run()")
+	}
+
+	if _, err := dmi.SearchByType(1); err == nil {
+		t.Error("Should have received an error when Search ran prior to .Run()")
+	}
+
+	if _, err := dmi.GenericSearchBy("DMIName", "System Information"); err == nil {
+		t.Error("Should have received an error when Search ran prior to .Run()")
+	}
+
+	if err := dmi.Run(); err != nil {
+		t.Errorf("Run() should not return any errors. Error: %v", err)
+	}
+
+	byNameData, byNameErr := dmi.SearchByName("System Information")
+	if byNameErr != nil {
+		t.Errorf("Shouldn't receive errors when searching by name. Error: %v", byNameErr)
+	}
+
+	if len(byNameData) == 0 {
+		t.Error("Returned data should have more than 0 records")
+	}
+
+	byTypeData, byTypeErr := dmi.SearchByType(1)
+	if byTypeErr != nil {
+		t.Errorf("Shouldn't receive errors when searching by name. Error: %v", byTypeErr)
+	}
+
+	if len(byTypeData) == 0 {
+		t.Error("Returned data should have more than 0 records")
+	}
+
+	genericData, genericErr := dmi.GenericSearchBy("DMIName", "System Information")
+	if genericErr != nil {
+		t.Errorf("Shouldn't receive errors when searching by name. Error: %v", genericErr)
+	}
+
+	if len(genericData) == 0 {
+		t.Error("Returned data should have more than 0 records")
+	}
+}

--- a/vendor/github.com/dselans/dmidecode/test_data/centos_6.5_64bit_dell.txt
+++ b/vendor/github.com/dselans/dmidecode/test_data/centos_6.5_64bit_dell.txt
@@ -1,0 +1,839 @@
+# dmidecode 2.12
+SMBIOS 2.6 present.
+78 structures occupying 4556 bytes.
+Table at 0xCF49C000.
+
+Handle 0xDA00, DMI type 218, 11 bytes
+OEM-specific Type
+	Header and Data:
+		DA 0B 00 DA B2 00 17 00 0E 20 00
+
+Handle 0x0000, DMI type 0, 24 bytes
+BIOS Information
+	Vendor: Dell Inc.
+	Version: 1.12.0
+	Release Date: 07/26/2013
+	Address: 0xF0000
+	Runtime Size: 64 kB
+	ROM Size: 4096 kB
+	Characteristics:
+		ISA is supported
+		PCI is supported
+		PNP is supported
+		BIOS is upgradeable
+		BIOS shadowing is allowed
+		Boot from CD is supported
+		Selectable boot is supported
+		EDD is supported
+		Japanese floppy for Toshiba 1.2 MB is supported (int 13h)
+		5.25"/360 kB floppy services are supported (int 13h)
+		5.25"/1.2 MB floppy services are supported (int 13h)
+		3.5"/720 kB floppy services are supported (int 13h)
+		8042 keyboard services are supported (int 9h)
+		Serial services are supported (int 14h)
+		CGA/mono video services are supported (int 10h)
+		ACPI is supported
+		USB legacy is supported
+		BIOS boot specification is supported
+		Function key-initiated network boot is supported
+		Targeted content distribution is supported
+	BIOS Revision: 1.12
+
+Handle 0x0100, DMI type 1, 27 bytes
+System Information
+	Manufacturer: Dell Inc.
+	Product Name: PowerEdge R510
+	Version: Not Specified
+	Serial Number: 23V2JN1
+	UUID: 4C4C4544-0033-5610-8032-B2C04F4A4E31
+	Wake-up Type: Power Switch
+	SKU Number: Not Specified
+	Family: Not Specified
+
+Handle 0x0200, DMI type 2, 9 bytes
+Base Board Information
+	Manufacturer: Dell Inc.
+	Product Name: 00HDP0
+	Version: A03
+	Serial Number: ..CN1374006C02CV.
+	Asset Tag: Not Specified
+
+Handle 0x0300, DMI type 3, 21 bytes
+Chassis Information
+	Manufacturer: Dell Inc.
+	Type: Rack Mount Chassis
+	Lock: Present
+	Version: Not Specified
+	Serial Number: 23V2JN1
+	Asset Tag: Not Specified
+	Boot-up State: Safe
+	Power Supply State: Safe
+	Thermal State: Safe
+	Security Status: Unknown
+	OEM Information: 0x00000000
+	Height: 1 U
+	Number Of Power Cords: Unspecified
+	Contained Elements: 0
+
+Handle 0x0400, DMI type 4, 40 bytes
+Processor Information
+	Socket Designation: CPU1
+	Type: Central Processor
+	Family: Xeon
+	Manufacturer: Intel
+	ID: C2 06 02 00 FF FB EB BF
+	Signature: Type 0, Family 6, Model 44, Stepping 2
+	Flags:
+		FPU (Floating-point unit on-chip)
+		VME (Virtual mode extension)
+		DE (Debugging extension)
+		PSE (Page size extension)
+		TSC (Time stamp counter)
+		MSR (Model specific registers)
+		PAE (Physical address extension)
+		MCE (Machine check exception)
+		CX8 (CMPXCHG8 instruction supported)
+		APIC (On-chip APIC hardware supported)
+		SEP (Fast system call)
+		MTRR (Memory type range registers)
+		PGE (Page global enable)
+		MCA (Machine check architecture)
+		CMOV (Conditional move instruction supported)
+		PAT (Page attribute table)
+		PSE-36 (36-bit page size extension)
+		CLFSH (CLFLUSH instruction supported)
+		DS (Debug store)
+		ACPI (ACPI supported)
+		MMX (MMX technology supported)
+		FXSR (FXSAVE and FXSTOR instructions supported)
+		SSE (Streaming SIMD extensions)
+		SSE2 (Streaming SIMD extensions 2)
+		SS (Self-snoop)
+		HTT (Multi-threading)
+		TM (Thermal monitor supported)
+		PBE (Pending break enabled)
+	Version: Intel(R) Xeon(R) CPU           X5650  @ 2.67GHz
+	Voltage: 1.2 V
+	External Clock: 6400 MHz
+	Max Speed: 3600 MHz
+	Current Speed: 2666 MHz
+	Status: Populated, Enabled
+	Upgrade: Socket LGA1366
+	L1 Cache Handle: 0x0700
+	L2 Cache Handle: 0x0701
+	L3 Cache Handle: 0x0702
+	Serial Number: Not Specified
+	Asset Tag: Not Specified
+	Part Number: Not Specified
+	Core Count: 6
+	Core Enabled: 6
+	Thread Count: 12
+	Characteristics:
+		64-bit capable
+
+Handle 0x0401, DMI type 4, 40 bytes
+Processor Information
+	Socket Designation: CPU2
+	Type: Central Processor
+	Family: Xeon
+	Manufacturer: Intel
+	ID: C2 06 02 00 FF FB EB BF
+	Signature: Type 0, Family 6, Model 44, Stepping 2
+	Flags:
+		FPU (Floating-point unit on-chip)
+		VME (Virtual mode extension)
+		DE (Debugging extension)
+		PSE (Page size extension)
+		TSC (Time stamp counter)
+		MSR (Model specific registers)
+		PAE (Physical address extension)
+		MCE (Machine check exception)
+		CX8 (CMPXCHG8 instruction supported)
+		APIC (On-chip APIC hardware supported)
+		SEP (Fast system call)
+		MTRR (Memory type range registers)
+		PGE (Page global enable)
+		MCA (Machine check architecture)
+		CMOV (Conditional move instruction supported)
+		PAT (Page attribute table)
+		PSE-36 (36-bit page size extension)
+		CLFSH (CLFLUSH instruction supported)
+		DS (Debug store)
+		ACPI (ACPI supported)
+		MMX (MMX technology supported)
+		FXSR (FXSAVE and FXSTOR instructions supported)
+		SSE (Streaming SIMD extensions)
+		SSE2 (Streaming SIMD extensions 2)
+		SS (Self-snoop)
+		HTT (Multi-threading)
+		TM (Thermal monitor supported)
+		PBE (Pending break enabled)
+	Version: Intel(R) Xeon(R) CPU           X5650  @ 2.67GHz
+	Voltage: 1.2 V
+	External Clock: 6400 MHz
+	Max Speed: 3600 MHz
+	Current Speed: 2666 MHz
+	Status: Populated, Idle
+	Upgrade: Socket LGA1366
+	L1 Cache Handle: 0x0703
+	L2 Cache Handle: 0x0704
+	L3 Cache Handle: 0x0705
+	Serial Number: Not Specified
+	Asset Tag: Not Specified
+	Part Number: Not Specified
+	Core Count: 6
+	Core Enabled: 6
+	Thread Count: 12
+	Characteristics:
+		64-bit capable
+
+Handle 0x0700, DMI type 7, 19 bytes
+Cache Information
+	Socket Designation: Not Specified
+	Configuration: Enabled, Not Socketed, Level 1
+	Operational Mode: Write Back
+	Location: Internal
+	Installed Size: 192 kB
+	Maximum Size: 192 kB
+	Supported SRAM Types:
+		Unknown
+	Installed SRAM Type: Unknown
+	Speed: Unknown
+	Error Correction Type: Single-bit ECC
+	System Type: Data
+	Associativity: 8-way Set-associative
+
+Handle 0x0701, DMI type 7, 19 bytes
+Cache Information
+	Socket Designation: Not Specified
+	Configuration: Enabled, Not Socketed, Level 2
+	Operational Mode: Write Back
+	Location: Internal
+	Installed Size: 1536 kB
+	Maximum Size: 2048 kB
+	Supported SRAM Types:
+		Unknown
+	Installed SRAM Type: Unknown
+	Speed: Unknown
+	Error Correction Type: Single-bit ECC
+	System Type: Unified
+	Associativity: 8-way Set-associative
+
+Handle 0x0702, DMI type 7, 19 bytes
+Cache Information
+	Socket Designation: Not Specified
+	Configuration: Enabled, Not Socketed, Level 3
+	Operational Mode: Write Back
+	Location: Internal
+	Installed Size: 12288 kB
+	Maximum Size: 12288 kB
+	Supported SRAM Types:
+		Unknown
+	Installed SRAM Type: Unknown
+	Speed: Unknown
+	Error Correction Type: Single-bit ECC
+	System Type: Unified
+	Associativity: 16-way Set-associative
+
+Handle 0x0703, DMI type 7, 19 bytes
+Cache Information
+	Socket Designation: Not Specified
+	Configuration: Enabled, Not Socketed, Level 1
+	Operational Mode: Write Back
+	Location: Internal
+	Installed Size: 192 kB
+	Maximum Size: 192 kB
+	Supported SRAM Types:
+		Unknown
+	Installed SRAM Type: Unknown
+	Speed: Unknown
+	Error Correction Type: Single-bit ECC
+	System Type: Data
+	Associativity: 8-way Set-associative
+
+Handle 0x0704, DMI type 7, 19 bytes
+Cache Information
+	Socket Designation: Not Specified
+	Configuration: Enabled, Not Socketed, Level 2
+	Operational Mode: Write Back
+	Location: Internal
+	Installed Size: 1536 kB
+	Maximum Size: 2048 kB
+	Supported SRAM Types:
+		Unknown
+	Installed SRAM Type: Unknown
+	Speed: Unknown
+	Error Correction Type: Single-bit ECC
+	System Type: Unified
+	Associativity: 8-way Set-associative
+
+Handle 0x0705, DMI type 7, 19 bytes
+Cache Information
+	Socket Designation: Not Specified
+	Configuration: Enabled, Not Socketed, Level 3
+	Operational Mode: Write Back
+	Location: Internal
+	Installed Size: 12288 kB
+	Maximum Size: 12288 kB
+	Supported SRAM Types:
+		Unknown
+	Installed SRAM Type: Unknown
+	Speed: Unknown
+	Error Correction Type: Single-bit ECC
+	System Type: Unified
+	Associativity: 16-way Set-associative
+
+Handle 0x0800, DMI type 8, 9 bytes
+Port Connector Information
+	Internal Reference Designator: Not Specified
+	Internal Connector Type: None
+	External Reference Designator: Not Specified
+	External Connector Type: DB-15 female
+	Port Type: Video Port
+
+Handle 0x0801, DMI type 8, 9 bytes
+Port Connector Information
+	Internal Reference Designator: Not Specified
+	Internal Connector Type: None
+	External Reference Designator: Not Specified
+	External Connector Type: DB-15 female
+	Port Type: Video Port
+
+Handle 0x0802, DMI type 8, 9 bytes
+Port Connector Information
+	Internal Reference Designator: Not Specified
+	Internal Connector Type: None
+	External Reference Designator: Not Specified
+	External Connector Type: Access Bus (USB)
+	Port Type: USB
+
+Handle 0x0803, DMI type 8, 9 bytes
+Port Connector Information
+	Internal Reference Designator: Not Specified
+	Internal Connector Type: None
+	External Reference Designator: Not Specified
+	External Connector Type: Access Bus (USB)
+	Port Type: USB
+
+Handle 0x0804, DMI type 126, 9 bytes
+Inactive
+
+Handle 0x0805, DMI type 126, 9 bytes
+Inactive
+
+Handle 0x0806, DMI type 126, 9 bytes
+Inactive
+
+Handle 0x0807, DMI type 126, 9 bytes
+Inactive
+
+Handle 0x0808, DMI type 8, 9 bytes
+Port Connector Information
+	Internal Reference Designator: Not Specified
+	Internal Connector Type: None
+	External Reference Designator: Not Specified
+	External Connector Type: Access Bus (USB)
+	Port Type: USB
+
+Handle 0x0809, DMI type 126, 9 bytes
+Inactive
+
+Handle 0x080A, DMI type 8, 9 bytes
+Port Connector Information
+	Internal Reference Designator: INT_USB1
+	Internal Connector Type: Access Bus (USB)
+	External Reference Designator: Not Specified
+	External Connector Type: None
+	Port Type: USB
+
+Handle 0x080B, DMI type 8, 9 bytes
+Port Connector Information
+	Internal Reference Designator: INT_USB2
+	Internal Connector Type: Access Bus (USB)
+	External Reference Designator: Not Specified
+	External Connector Type: None
+	Port Type: USB
+
+Handle 0x080C, DMI type 126, 9 bytes
+Inactive
+
+Handle 0x080D, DMI type 126, 9 bytes
+Inactive
+
+Handle 0x080E, DMI type 8, 9 bytes
+Port Connector Information
+	Internal Reference Designator: Not Specified
+	Internal Connector Type: None
+	External Reference Designator: Not Specified
+	External Connector Type: RJ-45
+	Port Type: Network Port
+
+Handle 0x080F, DMI type 8, 9 bytes
+Port Connector Information
+	Internal Reference Designator: Not Specified
+	Internal Connector Type: None
+	External Reference Designator: Not Specified
+	External Connector Type: RJ-45
+	Port Type: Network Port
+
+Handle 0x0810, DMI type 8, 9 bytes
+Port Connector Information
+	Internal Reference Designator: Not Specified
+	Internal Connector Type: None
+	External Reference Designator: Not Specified
+	External Connector Type: DB-9 male
+	Port Type: Serial Port 16550A Compatible
+
+Handle 0x0900, DMI type 9, 17 bytes
+System Slot Information
+	Designation: PCI1
+	Type: x4 PCI Express 2 x8
+	Current Usage: In Use
+	Length: Long
+	ID: 1
+	Characteristics:
+		3.3 V is provided
+		PME signal is supported
+	Bus Address: 0000:05:00.0
+
+Handle 0x0901, DMI type 9, 17 bytes
+System Slot Information
+	Designation: PCI2
+	Type: x4 PCI Express 2 x8
+	Current Usage: Available
+	Length: Long
+	ID: 2
+	Characteristics:
+		3.3 V is provided
+		PME signal is supported
+
+Handle 0x0902, DMI type 9, 17 bytes
+System Slot Information
+	Designation: PCI3
+	Type: x8 PCI Express 2 x8
+	Current Usage: Available
+	Length: Long
+	ID: 3
+	Characteristics:
+		3.3 V is provided
+		PME signal is supported
+
+Handle 0x0903, DMI type 9, 17 bytes
+System Slot Information
+	Designation: PCI4
+	Type: x4 PCI Express 2 x8
+	Current Usage: In Use
+	Length: Long
+	ID: 4
+	Characteristics:
+		3.3 V is provided
+		PME signal is supported
+	Bus Address: 0000:02:00.0
+
+Handle 0x0904, DMI type 126, 17 bytes
+Inactive
+
+Handle 0x0A00, DMI type 10, 10 bytes
+On Board Device 1 Information
+	Type: Video
+	Status: Enabled
+	Description: Embedded Matrox G200 Video
+On Board Device 2 Information
+	Type: Ethernet
+	Status: Enabled
+	Description: Embedded Broadcom 5716 NIC 1
+On Board Device 3 Information
+	Type: Ethernet
+	Status: Enabled
+	Description: Embedded Broadcom 5716 NIC 2
+
+Handle 0x0B00, DMI type 11, 5 bytes
+OEM Strings
+	String 1: Dell System
+	String 2: 5[0000]
+
+Handle 0x7E00, DMI type 126, 170 bytes
+Inactive
+
+Handle 0x0C00, DMI type 12, 5 bytes
+System Configuration Options
+	Option 1: NVRAM_CLR:  Clear user settable NVRAM areas and set defaults
+	Option 2: PWRD_EN:  Close to enable password
+
+Handle 0x0D00, DMI type 13, 22 bytes
+BIOS Language Information
+	Language Description Format: Long
+	Installable Languages: 1
+		en|US|iso8859-1
+	Currently Installed Language: en|US|iso8859-1
+
+Handle 0x1000, DMI type 16, 15 bytes
+Physical Memory Array
+	Location: System Board Or Motherboard
+	Use: System Memory
+	Error Correction Type: Multi-bit ECC
+	Maximum Capacity: 128 GB
+	Error Information Handle: Not Provided
+	Number Of Devices: 8
+
+Handle 0x1100, DMI type 17, 28 bytes
+Memory Device
+	Array Handle: 0x1000
+	Error Information Handle: Not Provided
+	Total Width: 72 bits
+	Data Width: 64 bits
+	Size: 8192 MB
+	Form Factor: DIMM
+	Set: 1
+	Locator: DIMM_A1
+	Bank Locator: Not Specified
+	Type: DDR3
+	Type Detail: Synchronous Registered (Buffered)
+	Speed: 1333 MHz
+	Manufacturer: 00CE00B380CE
+	Serial Number: 4741E48B
+	Asset Tag: 01102761
+	Part Number: M393B1K70CHD-CH9
+	Rank: 2
+
+Handle 0x1101, DMI type 17, 28 bytes
+Memory Device
+	Array Handle: 0x1000
+	Error Information Handle: Not Provided
+	Total Width: 72 bits
+	Data Width: 64 bits
+	Size: 8192 MB
+	Form Factor: DIMM
+	Set: 1
+	Locator: DIMM_A2
+	Bank Locator: Not Specified
+	Type: DDR3
+	Type Detail: Synchronous Registered (Buffered)
+	Speed: 1333 MHz
+	Manufacturer: 00CE00B380CE
+	Serial Number: 4741E40F
+	Asset Tag: 01102761
+	Part Number: M393B1K70CHD-CH9
+	Rank: 2
+
+Handle 0x1102, DMI type 17, 28 bytes
+Memory Device
+	Array Handle: 0x1000
+	Error Information Handle: Not Provided
+	Total Width: 72 bits
+	Data Width: 64 bits
+	Size: 8192 MB
+	Form Factor: DIMM
+	Set: 2
+	Locator: DIMM_A3
+	Bank Locator: Not Specified
+	Type: DDR3
+	Type Detail: Synchronous Registered (Buffered)
+	Speed: 1333 MHz
+	Manufacturer: 00CE00B380CE
+	Serial Number: 4741E483
+	Asset Tag: 01102761
+	Part Number: M393B1K70CHD-CH9
+	Rank: 2
+
+Handle 0x1103, DMI type 17, 28 bytes
+Memory Device
+	Array Handle: 0x1000
+	Error Information Handle: Not Provided
+	Total Width: 72 bits
+	Data Width: 64 bits
+	Size: No Module Installed
+	Form Factor: DIMM
+	Set: 2
+	Locator: DIMM_A4
+	Bank Locator: Not Specified
+	Type: DDR3
+	Type Detail: Synchronous
+	Speed: Unknown
+	Manufacturer:
+	Serial Number:
+	Asset Tag:
+	Part Number:
+	Rank: Unknown
+
+Handle 0x1104, DMI type 126, 28 bytes
+Inactive
+
+Handle 0x1105, DMI type 126, 28 bytes
+Inactive
+
+Handle 0x1106, DMI type 126, 28 bytes
+Inactive
+
+Handle 0x1107, DMI type 126, 28 bytes
+Inactive
+
+Handle 0x1108, DMI type 126, 28 bytes
+Inactive
+
+Handle 0x1109, DMI type 17, 28 bytes
+Memory Device
+	Array Handle: 0x1000
+	Error Information Handle: Not Provided
+	Total Width: 72 bits
+	Data Width: 64 bits
+	Size: 8192 MB
+	Form Factor: DIMM
+	Set: 5
+	Locator: DIMM_B1
+	Bank Locator: Not Specified
+	Type: DDR3
+	Type Detail: Synchronous Registered (Buffered)
+	Speed: 1333 MHz
+	Manufacturer: 00CE00B380CE
+	Serial Number: 4741E414
+	Asset Tag: 01102761
+	Part Number: M393B1K70CHD-CH9
+	Rank: 2
+
+Handle 0x110A, DMI type 17, 28 bytes
+Memory Device
+	Array Handle: 0x1000
+	Error Information Handle: Not Provided
+	Total Width: 72 bits
+	Data Width: 64 bits
+	Size: 8192 MB
+	Form Factor: DIMM
+	Set: 6
+	Locator: DIMM_B2
+	Bank Locator: Not Specified
+	Type: DDR3
+	Type Detail: Synchronous Registered (Buffered)
+	Speed: 1333 MHz
+	Manufacturer: 00CE00B380CE
+	Serial Number: 4741E413
+	Asset Tag: 01102761
+	Part Number: M393B1K70CHD-CH9
+	Rank: 2
+
+Handle 0x110B, DMI type 17, 28 bytes
+Memory Device
+	Array Handle: 0x1000
+	Error Information Handle: Not Provided
+	Total Width: 72 bits
+	Data Width: 64 bits
+	Size: 8192 MB
+	Form Factor: DIMM
+	Set: 6
+	Locator: DIMM_B3
+	Bank Locator: Not Specified
+	Type: DDR3
+	Type Detail: Synchronous Registered (Buffered)
+	Speed: 1333 MHz
+	Manufacturer: 00CE00B380CE
+	Serial Number: 4741E47E
+	Asset Tag: 01102761
+	Part Number: M393B1K70CHD-CH9
+	Rank: 2
+
+Handle 0x110C, DMI type 17, 28 bytes
+Memory Device
+	Array Handle: 0x1000
+	Error Information Handle: Not Provided
+	Total Width: 72 bits
+	Data Width: 64 bits
+	Size: No Module Installed
+	Form Factor: DIMM
+	Set: 4
+	Locator: DIMM_B4
+	Bank Locator: Not Specified
+	Type: DDR3
+	Type Detail: Synchronous
+	Speed: Unknown
+	Manufacturer:
+	Serial Number:
+	Asset Tag:
+	Part Number:
+	Rank: Unknown
+
+Handle 0x110D, DMI type 126, 28 bytes
+Inactive
+
+Handle 0x110E, DMI type 126, 28 bytes
+Inactive
+
+Handle 0x110F, DMI type 126, 28 bytes
+Inactive
+
+Handle 0x1110, DMI type 126, 28 bytes
+Inactive
+
+Handle 0x1111, DMI type 126, 28 bytes
+Inactive
+
+Handle 0x1300, DMI type 19, 15 bytes
+Memory Array Mapped Address
+	Starting Address: 0x00000000000
+	Ending Address: 0x000CFFFFFFF
+	Range Size: 3328 MB
+	Physical Array Handle: 0x1000
+	Partition Width: 2
+
+Handle 0x1301, DMI type 19, 15 bytes
+Memory Array Mapped Address
+	Starting Address: 0x00100000000
+	Ending Address: 0x00C2FFFFFFF
+	Range Size: 45824 MB
+	Physical Array Handle: 0x1000
+	Partition Width: 2
+
+Handle 0x2000, DMI type 32, 11 bytes
+System Boot Information
+	Status: No errors detected
+
+Handle 0x2600, DMI type 38, 18 bytes
+IPMI Device Information
+	Interface Type: KCS (Keyboard Control Style)
+	Specification Version: 2.0
+	I2C Slave Address: 0x10
+	NV Storage Device: Not Present
+	Base Address: 0x0000000000000CA8 (I/O)
+	Register Spacing: 32-bit Boundaries
+
+Handle 0x2900, DMI type 41, 11 bytes
+Onboard Device
+	Reference Designation: Embedded NIC 1
+	Type: Ethernet
+	Status: Enabled
+	Type Instance: 1
+	Bus Address: 0000:01:00.0
+
+Handle 0x2901, DMI type 41, 11 bytes
+Onboard Device
+	Reference Designation: Embedded NIC 2
+	Type: Ethernet
+	Status: Enabled
+	Type Instance: 2
+	Bus Address: 0000:01:00.1
+
+Handle 0x2902, DMI type 126, 11 bytes
+Inactive
+
+Handle 0x2903, DMI type 126, 11 bytes
+Inactive
+
+Handle 0x2904, DMI type 41, 11 bytes
+Onboard Device
+	Reference Designation: Embedded Video
+	Type: Video
+	Status: Enabled
+	Type Instance: 4
+	Bus Address: 0000:06:03.0
+
+Handle 0xD000, DMI type 208, 16 bytes
+OEM-specific Type
+	Header and Data:
+		D0 10 00 D0 02 00 FE 00 F1 02 00 00 01 01 00 00
+
+Handle 0xD200, DMI type 210, 12 bytes
+OEM-specific Type
+	Header and Data:
+		D2 0C 00 D2 F8 03 04 03 06 80 04 05
+
+Handle 0xD400, DMI type 212, 87 bytes
+OEM-specific Type
+	Header and Data:
+		D4 57 00 D4 70 00 71 00 00 10 2D 2E 42 00 11 FE
+		01 43 00 11 FE 00 00 00 11 9F 20 00 00 11 9F 00
+		00 00 11 9F 20 00 00 11 9F 00 31 40 11 FB 00 32
+		40 11 FB 04 9D 00 11 FD 02 9E 00 11 FD 00 9F 00
+		26 FE 01 A0 00 26 FE 00 28 40 26 DF 20 29 40 26
+		DF 00 FF FF 00 00 00
+
+Handle 0xD401, DMI type 212, 252 bytes
+OEM-specific Type
+	Header and Data:
+		D4 FC 01 D4 70 00 71 00 03 40 5A 6D 5C 00 78 BF
+		40 5D 00 78 BF 00 6C 01 57 FC 00 6B 01 57 FC 01
+		6A 01 57 FC 02 76 02 57 EF 00 75 02 57 EF 10 74
+		02 57 DF 00 73 02 57 DF 20 77 01 54 FC 00 78 01
+		54 FC 01 79 01 54 FC 02 7A 01 54 FC 03 33 40 54
+		CF 00 34 40 54 CF 10 35 40 54 CF 20 36 40 54 CF
+		30 1A 40 54 FB 04 1B 40 54 FB 00 1C 40 54 F7 08
+		1D 40 54 F7 00 43 40 58 DF 20 42 40 58 DF 00 24
+		40 58 BF 40 25 40 58 BF 00 6E 00 58 FC 01 2D 00
+		58 FC 02 DA 01 58 FC 03 22 40 58 EF 10 23 40 58
+		EF 00 BB 00 58 F3 04 BC 00 58 F3 08 DB 01 58 F3
+		0C 2D 02 55 FE 01 2E 02 55 FE 00 D8 00 55 7F 80
+		D9 00 55 7F 00 54 02 56 DF 00 57 02 56 DF 20 4D
+		02 56 BF 00 4E 02 56 BF 40 2D 01 56 7F 80 2E 01
+		56 7F 00 00 C0 5C 00 0A 03 C0 67 00 05 83 00 76
+		00 00 84 00 77 00 00 FF FF 00 00 00
+
+Handle 0xD402, DMI type 212, 232 bytes
+OEM-specific Type
+	Header and Data:
+		D4 E8 02 D4 72 00 73 00 00 40 5D 5E D3 00 00 00
+		02 D4 00 02 00 02 4A 01 46 BF 40 4B 01 46 BF 00
+		00 90 2C 00 00 01 90 2D 00 00 DA 00 49 EB 14 00
+		00 49 EF 10 D2 02 49 EF 00 D3 02 49 EF 10 D6 02
+		49 EF 00 D7 02 49 EF 10 00 00 49 FB 04 D4 02 49
+		FB 00 D5 02 49 FB 04 00 00 49 EB 00 00 00 49 7F
+		00 00 00 49 7F 80 5D 02 49 FC 00 5E 02 49 FC 01
+		5F 02 49 FC 02 60 02 49 FC 03 C5 02 48 BF 00 C6
+		02 48 BF 40 C7 02 48 DF 00 C8 02 48 DF 20 C9 02
+		48 EF 00 CA 02 48 EF 10 DE 00 63 FE 01 26 40 42
+		FE 01 27 40 42 FE 00 FF 02 42 F7 08 00 03 42 F7
+		00 01 03 42 EF 10 02 03 42 EF 00 02 40 46 DF 00
+		01 40 46 DF 20 CF 01 40 FD 02 D0 01 40 FD 00 FC
+		01 45 BF 00 FD 01 45 BF 40 00 00 45 7F 80 00 00
+		45 7F 00 FF FF 00 00 00
+
+Handle 0xD403, DMI type 212, 237 bytes
+OEM-specific Type
+	Header and Data:
+		D4 ED 03 D4 72 00 73 00 00 40 5D 5E D1 00 46 FE
+		00 D2 00 46 FE 01 71 01 46 FB 04 72 01 46 FB 00
+		73 01 46 F7 08 74 01 46 F7 00 40 01 47 EF 10 41
+		01 47 EF 00 EB 01 47 FD 00 EA 01 47 FD 02 33 02
+		47 F3 04 32 02 47 F3 08 31 02 47 F3 0C 6F 02 47
+		F3 00 6E 02 47 F3 00 4B 02 47 DF 00 4C 02 47 DF
+		20 17 01 4A FE 00 18 01 4A FE 01 19 01 4A FD 00
+		1A 01 4A FD 02 35 01 4B FC 00 37 01 4B FC 01 00
+		00 4B FC 02 3B 01 4B F3 04 F7 02 4B 7F 80 F8 02
+		4B 7F 00 C4 01 50 FE 00 C5 01 50 FE 01 99 02 5C
+		F7 00 98 02 5C F7 08 AE 02 5C FB 00 AD 02 5C FB
+		04 00 00 5C 3F 40 00 00 5C 3F 80 B8 02 5C 3F 00
+		1B 01 4A FB 00 1C 01 4A FB 04 1D 01 4A F7 00 1E
+		01 4A F7 08 1F 01 44 FE 00 20 01 44 FE 01 00 00
+		44 FD 00 00 00 44 FD 02 FF FF 00 00 00
+
+Handle 0xD800, DMI type 216, 9 bytes
+OEM-specific Type
+	Header and Data:
+		D8 09 00 D8 01 02 01 00 00
+	Strings:
+		MATROX
+		VGA/VBE BIOS, Version V3.8WO
+
+Handle 0xDE00, DMI type 222, 16 bytes
+OEM-specific Type
+	Header and Data:
+		DE 10 00 DE 01 08 00 00 14 01 24 03 43 08 00 01
+
+Handle 0xE100, DMI type 225, 45 bytes
+OEM-specific Type
+	Header and Data:
+		E1 2D 00 E1 01 01 00 04 00 02 01 04 00 03 00 11
+		00 04 01 11 00 05 02 11 00 06 03 11 00 07 09 11
+		00 08 0A 11 00 09 0B 11 00 0A 0C 11 00
+	Strings:
+		CPU.Socket.1
+		CPU.Socket.2
+		DIMM.Socket.A1
+		DIMM.Socket.A2
+		DIMM.Socket.A3
+		DIMM.Socket.A4
+		DIMM.Socket.B1
+		DIMM.Socket.B2
+		DIMM.Socket.B3
+		DIMM.Socket.B4
+
+Handle 0x7F00, DMI type 127, 4 bytes
+End Of Table
+

--- a/vendor/github.com/dselans/dmidecode/test_data/centos_6.5_64bit_oem.txt
+++ b/vendor/github.com/dselans/dmidecode/test_data/centos_6.5_64bit_oem.txt
@@ -1,0 +1,386 @@
+# dmidecode 2.12
+SMBIOS 2.4 present.
+28 structures occupying 1399 bytes.
+Table at 0x000FB9C0.
+
+Handle 0x0000, DMI type 0, 24 bytes
+BIOS Information
+	Vendor: American Megatrends Inc.
+	Version: P1.30
+	Release Date: 10/27/2006
+	Address: 0xF0000
+	Runtime Size: 64 kB
+	ROM Size: 512 kB
+	Characteristics:
+		PCI is supported
+		PNP is supported
+		BIOS is upgradeable
+		BIOS shadowing is allowed
+		Boot from CD is supported
+		Selectable boot is supported
+		BIOS ROM is socketed
+		EDD is supported
+		5.25"/1.2 MB floppy services are supported (int 13h)
+		3.5"/720 kB floppy services are supported (int 13h)
+		3.5"/2.88 MB floppy services are supported (int 13h)
+		Print screen service is supported (int 5h)
+		8042 keyboard services are supported (int 9h)
+		Serial services are supported (int 14h)
+		Printer services are supported (int 17h)
+		CGA/mono video services are supported (int 10h)
+		ACPI is supported
+		USB legacy is supported
+		LS-120 boot is supported
+		ATAPI Zip drive boot is supported
+		BIOS boot specification is supported
+		Function key-initiated network boot is supported
+		Targeted content distribution is supported
+	BIOS Revision: 8.12
+
+Handle 0x0001, DMI type 1, 27 bytes
+System Information
+	Manufacturer: To Be Filled By O.E.M.
+	Product Name: To Be Filled By O.E.M.
+	Version: To Be Filled By O.E.M.
+	Serial Number: To Be Filled By O.E.M.
+	UUID: 00020003-0004-0005-0006-000700080009
+	Wake-up Type: Power Switch
+	SKU Number: To Be Filled By O.E.M.
+	Family: To Be Filled By O.E.M.
+
+Handle 0x0002, DMI type 2, 15 bytes
+Base Board Information
+	Manufacturer:
+	Product Name: ConRoe945G-DVI
+	Version:
+	Serial Number:
+	Asset Tag:
+	Features:
+		Board is a hosting board
+		Board is replaceable
+	Location In Chassis:
+	Chassis Handle: 0x0003
+	Type: Motherboard
+	Contained Object Handles: 0
+
+Handle 0x0003, DMI type 3, 21 bytes
+Chassis Information
+	Manufacturer: To Be Filled By O.E.M.
+	Type: Desktop
+	Lock: Not Present
+	Version: To Be Filled By O.E.M.
+	Serial Number: To Be Filled By O.E.M.
+	Asset Tag: To Be Filled By O.E.M.
+	Boot-up State: Safe
+	Power Supply State: Safe
+	Thermal State: Safe
+	Security Status: None
+	OEM Information: 0x00000000
+	Height: Unspecified
+	Number Of Power Cords: 1
+	Contained Elements: 0
+
+Handle 0x0004, DMI type 4, 35 bytes
+Processor Information
+	Socket Designation: CPUSocket
+	Type: Central Processor
+	Family: Core 2
+	Manufacturer: Intel
+	ID: F6 06 00 00 FF FB EB BF
+	Signature: Type 0, Family 6, Model 15, Stepping 6
+	Flags:
+		FPU (Floating-point unit on-chip)
+		VME (Virtual mode extension)
+		DE (Debugging extension)
+		PSE (Page size extension)
+		TSC (Time stamp counter)
+		MSR (Model specific registers)
+		PAE (Physical address extension)
+		MCE (Machine check exception)
+		CX8 (CMPXCHG8 instruction supported)
+		APIC (On-chip APIC hardware supported)
+		SEP (Fast system call)
+		MTRR (Memory type range registers)
+		PGE (Page global enable)
+		MCA (Machine check architecture)
+		CMOV (Conditional move instruction supported)
+		PAT (Page attribute table)
+		PSE-36 (36-bit page size extension)
+		CLFSH (CLFLUSH instruction supported)
+		DS (Debug store)
+		ACPI (ACPI supported)
+		MMX (MMX technology supported)
+		FXSR (FXSAVE and FXSTOR instructions supported)
+		SSE (Streaming SIMD extensions)
+		SSE2 (Streaming SIMD extensions 2)
+		SS (Self-snoop)
+		HTT (Multi-threading)
+		TM (Thermal monitor supported)
+		PBE (Pending break enabled)
+	Version: Intel(R) Core(TM)2 CPU          6600  @ 2.40GHz
+	Voltage: 1.3 V
+	External Clock: 266 MHz
+	Max Speed: 2400 MHz
+	Current Speed: 2400 MHz
+	Status: Populated, Enabled
+	Upgrade: Other
+	L1 Cache Handle: 0x0005
+	L2 Cache Handle: 0x0006
+	L3 Cache Handle: Not Provided
+	Serial Number: To Be Filled By O.E.M.
+	Asset Tag: To Be Filled By O.E.M.
+	Part Number: To Be Filled By O.E.M.
+
+Handle 0x0005, DMI type 7, 19 bytes
+Cache Information
+	Socket Designation: L1-Cache
+	Configuration: Enabled, Not Socketed, Level 1
+	Operational Mode: Write Back
+	Location: Internal
+	Installed Size: 64 kB
+	Maximum Size: 64 kB
+	Supported SRAM Types:
+		Other
+	Installed SRAM Type: Other
+	Speed: Unknown
+	Error Correction Type: Parity
+	System Type: Data
+	Associativity: 8-way Set-associative
+
+Handle 0x0006, DMI type 7, 19 bytes
+Cache Information
+	Socket Designation: L2-Cache
+	Configuration: Enabled, Not Socketed, Level 2
+	Operational Mode: Write Back
+	Location: Internal
+	Installed Size: 4096 kB
+	Maximum Size: 4096 kB
+	Supported SRAM Types:
+		Other
+	Installed SRAM Type: Other
+	Speed: Unknown
+	Error Correction Type: Single-bit ECC
+	System Type: Instruction
+	Associativity: 8-way Set-associative
+
+Handle 0x0007, DMI type 5, 24 bytes
+Memory Controller Information
+	Error Detecting Method: 64-bit ECC
+	Error Correcting Capabilities:
+		None
+	Supported Interleave: One-way Interleave
+	Current Interleave: One-way Interleave
+	Maximum Memory Module Size: 4096 MB
+	Maximum Total Memory Size: 16384 MB
+	Supported Speeds:
+		Other
+	Supported Memory Types:
+		DIMM
+		SDRAM
+	Memory Module Voltage: 3.3 V
+	Associated Memory Slots: 4
+		0x0008
+		0x0009
+		0x000A
+		0x000B
+	Enabled Error Correcting Capabilities:
+		None
+
+Handle 0x0008, DMI type 6, 12 bytes
+Memory Module Information
+	Socket Designation: DIMM0
+	Bank Connections: 0 1
+	Current Speed: Unknown
+	Type: DIMM SDRAM
+	Installed Size: 1024 MB (Double-bank Connection)
+	Enabled Size: 1024 MB (Double-bank Connection)
+	Error Status: OK
+
+Handle 0x0009, DMI type 6, 12 bytes
+Memory Module Information
+	Socket Designation: DIMM1
+	Bank Connections: 2 3
+	Current Speed: Unknown
+	Type: DIMM SDRAM
+	Installed Size: Not Installed
+	Enabled Size: Not Installed
+	Error Status: OK
+
+Handle 0x000A, DMI type 6, 12 bytes
+Memory Module Information
+	Socket Designation: DIMM2
+	Bank Connections: 4 5
+	Current Speed: Unknown
+	Type: DIMM SDRAM
+	Installed Size: Not Installed
+	Enabled Size: Not Installed
+	Error Status: OK
+
+Handle 0x000B, DMI type 6, 12 bytes
+Memory Module Information
+	Socket Designation: DIMM3
+	Bank Connections: 6 7
+	Current Speed: Unknown
+	Type: DIMM SDRAM
+	Installed Size: Not Installed
+	Enabled Size: Not Installed
+	Error Status: OK
+
+Handle 0x000C, DMI type 9, 13 bytes
+System Slot Information
+	Designation: PCI1
+	Type: 32-bit PCI
+	Current Usage: In Use
+	Length: Short
+	ID: 1
+	Characteristics:
+		3.3 V is provided
+		Opening is shared
+		PME signal is supported
+
+Handle 0x000D, DMI type 9, 13 bytes
+System Slot Information
+	Designation: PCI2
+	Type: 32-bit PCI
+	Current Usage: Available
+	Length: Short
+	ID: 2
+	Characteristics:
+		3.3 V is provided
+		Opening is shared
+		PME signal is supported
+
+Handle 0x000E, DMI type 126, 13 bytes
+Inactive
+
+Handle 0x000F, DMI type 9, 13 bytes
+System Slot Information
+	Designation: PCIE2
+	Type: x1 PCI Express
+	Current Usage: Available
+	Length: Short
+	ID: 18
+	Characteristics:
+		3.3 V is provided
+		Opening is shared
+		PME signal is supported
+
+Handle 0x0010, DMI type 16, 15 bytes
+Physical Memory Array
+	Location: System Board Or Motherboard
+	Use: System Memory
+	Error Correction Type: None
+	Maximum Capacity: 4 GB
+	Error Information Handle: Not Provided
+	Number Of Devices: 4
+
+Handle 0x0011, DMI type 19, 15 bytes
+Memory Array Mapped Address
+	Starting Address: 0x00000000000
+	Ending Address: 0x0003FFFFFFF
+	Range Size: 1 GB
+	Physical Array Handle: 0x0010
+	Partition Width: 4
+
+Handle 0x0012, DMI type 17, 27 bytes
+Memory Device
+	Array Handle: 0x0010
+	Error Information Handle: Not Provided
+	Total Width: 64 bits
+	Data Width: 64 bits
+	Size: 1024 MB
+	Form Factor: DIMM
+	Set: None
+	Locator: DIMM0
+	Bank Locator: BANK0
+	Type: SDRAM
+	Type Detail: Synchronous
+	Speed: Unknown
+	Manufacturer: Manufacturer0
+	Serial Number: SerNum0
+	Asset Tag: AssetTagNum0
+	Part Number: PartNum0
+
+Handle 0x0013, DMI type 20, 19 bytes
+Memory Device Mapped Address
+	Starting Address: 0x00000000000
+	Ending Address: 0x0003FFFFFFF
+	Range Size: 1 GB
+	Physical Device Handle: 0x0012
+	Memory Array Mapped Address Handle: 0x0011
+	Partition Row Position: 1
+	Interleaved Data Depth: 1
+
+Handle 0x0014, DMI type 17, 27 bytes
+Memory Device
+	Array Handle: 0x0010
+	Error Information Handle: Not Provided
+	Total Width: Unknown
+	Data Width: 64 bits
+	Size: No Module Installed
+	Form Factor: DIMM
+	Set: None
+	Locator: DIMM1
+	Bank Locator: BANK1
+	Type: Unknown
+	Type Detail: Unknown
+	Speed: Unknown
+	Manufacturer: Manufacturer1
+	Serial Number: SerNum1
+	Asset Tag: AssetTagNum1
+	Part Number: PartNum1
+
+Handle 0x0015, DMI type 126, 19 bytes
+Inactive
+
+Handle 0x0016, DMI type 17, 27 bytes
+Memory Device
+	Array Handle: 0x0010
+	Error Information Handle: Not Provided
+	Total Width: Unknown
+	Data Width: 64 bits
+	Size: No Module Installed
+	Form Factor: DIMM
+	Set: None
+	Locator: DIMM2
+	Bank Locator: BANK2
+	Type: Unknown
+	Type Detail: Unknown
+	Speed: Unknown
+	Manufacturer: Manufacturer2
+	Serial Number: SerNum2
+	Asset Tag: AssetTagNum2
+	Part Number: PartNum2
+
+Handle 0x0017, DMI type 126, 19 bytes
+Inactive
+
+Handle 0x0018, DMI type 17, 27 bytes
+Memory Device
+	Array Handle: 0x0010
+	Error Information Handle: Not Provided
+	Total Width: Unknown
+	Data Width: 64 bits
+	Size: No Module Installed
+	Form Factor: DIMM
+	Set: None
+	Locator: DIMM3
+	Bank Locator: BANK3
+	Type: Unknown
+	Type Detail: Unknown
+	Speed: Unknown
+	Manufacturer: Manufacturer3
+	Serial Number: SerNum3
+	Asset Tag: AssetTagNum3
+	Part Number: PartNum3
+
+Handle 0x0019, DMI type 126, 19 bytes
+Inactive
+
+Handle 0x001A, DMI type 32, 20 bytes
+System Boot Information
+	Status: No errors detected
+
+Handle 0x001B, DMI type 127, 4 bytes
+End Of Table
+

--- a/vendor/github.com/dselans/dmidecode/test_data/ubuntu_14.04_LTS_64bit_vmware.txt
+++ b/vendor/github.com/dselans/dmidecode/test_data/ubuntu_14.04_LTS_64bit_vmware.txt
@@ -1,0 +1,82 @@
+# dmidecode 2.12
+SMBIOS 2.5 present.
+10 structures occupying 449 bytes.
+Table at 0x000E1000.
+
+Handle 0x0000, DMI type 0, 20 bytes
+BIOS Information
+	Vendor: innotek GmbH
+	Version: VirtualBox
+	Release Date: 12/01/2006
+	Address: 0xE0000
+	Runtime Size: 128 kB
+	ROM Size: 128 kB
+	Characteristics:
+		ISA is supported
+		PCI is supported
+		Boot from CD is supported
+		Selectable boot is supported
+		8042 keyboard services are supported (int 9h)
+		CGA/mono video services are supported (int 10h)
+		ACPI is supported
+
+Handle 0x0001, DMI type 1, 27 bytes
+System Information
+	Manufacturer: innotek GmbH
+	Product Name: VirtualBox
+	Version: 1.2
+	Serial Number: 0
+	UUID: F548DD5F-057D-4F7F-9465-FC529E045C08
+	Wake-up Type: Power Switch
+	SKU Number: Not Specified
+	Family: Virtual Machine
+
+Handle 0x0008, DMI type 2, 15 bytes
+Base Board Information
+	Manufacturer: Oracle Corporation
+	Product Name: VirtualBox
+	Version: 1.2
+	Serial Number: 0
+	Asset Tag: Not Specified
+	Features:
+		Board is a hosting board
+	Location In Chassis: Not Specified
+	Chassis Handle: 0x0003
+	Type: Motherboard
+	Contained Object Handles: 0
+
+Handle 0x0003, DMI type 3, 13 bytes
+Chassis Information
+	Manufacturer: Oracle Corporation
+	Type: Other
+	Lock: Not Present
+	Version: Not Specified
+	Serial Number: Not Specified
+	Asset Tag: Not Specified
+	Boot-up State: Safe
+	Power Supply State: Safe
+	Thermal State: Safe
+	Security Status: None
+
+Handle 0x0007, DMI type 126, 42 bytes
+Inactive
+
+Handle 0x0005, DMI type 126, 15 bytes
+Inactive
+
+Handle 0x0006, DMI type 126, 28 bytes
+Inactive
+
+Handle 0x0002, DMI type 11, 7 bytes
+OEM Strings
+	String 1: vboxVer_4.3.20
+	String 2: vboxRev_96996
+
+Handle 0x0008, DMI type 128, 8 bytes
+OEM-specific Type
+	Header and Data:
+		80 08 08 00 E1 63 22 00
+
+Handle 0xFEFF, DMI type 127, 4 bytes
+End Of Table
+

--- a/vendor/github.com/profitbricks/profitbricks-sdk-go/.gitignore
+++ b/vendor/github.com/profitbricks/profitbricks-sdk-go/.gitignore
@@ -1,0 +1,35 @@
+# Compiled Object files, Static and Dynamic libs (Shared Objects)
+*.o
+*.a
+*.so
+
+# Folders
+_obj
+_test
+
+# Architecture specific extensions/prefixes
+*.[568vq]
+[568vq].out
+
+*.cgo1.go
+*.cgo2.c
+_cgo_defun.c
+_cgo_gotypes.go
+_cgo_export.*
+
+_testmain.go
+
+*.exe
+*.test
+*.prof
+/.idea/
+.idea/compiler.xml
+.idea/copyright/
+.idea/encodings.xml
+.idea/misc.xml
+.idea/modules.xml
+.idea/profitbricks-sdk-go.iml
+.idea/vcs.xml
+.idea/workspace.xml
+/.idea/libraries/
+.DS_Store

--- a/vendor/github.com/profitbricks/profitbricks-sdk-go/LICENSE
+++ b/vendor/github.com/profitbricks/profitbricks-sdk-go/LICENSE
@@ -1,0 +1,202 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "{}"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright 2015 ProfitBricks GmbH
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+

--- a/vendor/github.com/profitbricks/profitbricks-sdk-go/README.md
+++ b/vendor/github.com/profitbricks/profitbricks-sdk-go/README.md
@@ -1,0 +1,342 @@
+# Go SDK
+
+The ProfitBricks Client Library for [Go](https://www.golang.org/) provides you with access to the ProfitBricks REST API. It is designed for developers who are building applications in Go.
+
+This guide will walk you through getting setup with the library and performing various actions against the API.
+
+# Table of Contents
+* [Concepts](#concepts)
+* [Getting Started](#getting-started)
+* [Installation](#installation)
+* [How to: Create Data Center](#how-to-create-data-center)
+* [How to: Delete Data Center](#how-to-delete-data-center)
+* [How to: Create Server](#how-to-create-server)
+* [How to: List Available Images](#how-to-list-available-images)
+* [How to: Create Storage Volume](#how-to-create-storage-volume)
+* [How to: Update Cores and Memory](#how-to-update-cores-and-memory)
+* [How to: Attach or Detach Storage Volume](#how-to-attach-or-detach-storage-volume)
+* [How to: List Servers, Volumes, and Data Centers](#how-to-list-servers-volumes-and-data-centers)
+* [Example](#example)
+* [Return Types](#return-types)
+* [Support](#support)
+
+
+# Concepts
+
+The Go SDK wraps the latest version of the ProfitBricks REST API. All API operations are performed over SSL and authenticated using your ProfitBricks portal credentials. The API can be accessed within an instance running in ProfitBricks or directly over the Internet from any application that can send an HTTPS request and receive an HTTPS response.
+
+# Getting Started
+
+Before you begin you will need to have [signed-up](https://www.profitbricks.com/signup) for a ProfitBricks account. The credentials you setup during sign-up will be used to authenticate against the API.
+
+Install the Go language from: [Go Installation](https://golang.org/doc/install)
+
+The `GOPATH` environment variable specifies the location of your Go workspace. It is likely the only environment variable you'll need to set when developing Go code. This is an example of pointing to a workspace configured underneath your home directory:
+
+```
+mkdir -p ~/go/bin
+export GOPATH=~/go
+export GOBIN=$GOPATH/bin
+export PATH=$PATH:$GOBIN
+```
+
+# Installation
+
+The following go command will download `profitbricks-sdk-go` to your configured `GOPATH`:
+
+```go
+go get "github.com/profitbricks/profitbricks-sdk-go"
+```
+
+The source code of the package will be located at:
+
+	$GOBIN\src\profitbricks-sdk-go
+
+Create main package file *example.go*:
+
+```go
+package main
+
+import (
+	"fmt"
+)
+
+func main() {
+}
+```
+
+Import GO SDK:
+
+```go
+import(
+	"github.com/profitbricks/profitbricks-sdk-go"
+)
+```
+
+Add your credentials for connecting to ProfitBricks:
+
+```go
+profitbricks.SetAuth("username", "password")
+```
+
+Set depth:
+
+```go
+profitbricks.SetDepth("5")
+```
+
+Depth controls the amount of data returned from the REST server ( range 1-5 ). The larger the number the more information is returned from the server. This is especially useful if you are looking for the information in the nested objects.
+
+**Caution**: You will want to ensure you follow security best practices when using credentials within your code or stored in a file.
+
+# How To's
+
+## How To: Create Data Center
+
+ProfitBricks introduces the concept of Data Centers. These are logically separated from one another and allow you to have a self-contained environment for all servers, volumes, networking, snapshots, and so forth. The goal is to give you the same experience as you would have if you were running your own physical data center.
+
+The following code example shows you how to programmatically create a data center:
+
+```go
+dcrequest := profitbricks.Datacenter{
+		Properties: profitbricks.DatacenterProperties{
+			Name:        "example.go3",
+			Description: "description",
+			Location:    "us/lasdev",
+		},
+	}
+
+datacenter := profitbricks.CreateDatacenter(dcrequest)
+```
+
+## How To: Create Data Center with Multiple Resources
+
+To create a complex Data Center you would do this. As you can see, you can create quite a few of the objects you will need later all in one request.:
+
+```go
+datacenter := model.Datacenter{
+		Properties: model.DatacenterProperties{
+			Name: "composite test",
+			Location:location,
+		},
+		Entities:model.DatacenterEntities{
+			Servers: &model.Servers{
+				Items:[]model.Server{
+					model.Server{
+						Properties: model.ServerProperties{
+							Name : "server1",
+							Ram: 2048,
+							Cores: 1,
+						},
+						Entities:model.ServerEntities{
+							Volumes: &model.AttachedVolumes{
+								Items:[]model.Volume{
+									model.Volume{
+										Properties: model.VolumeProperties{
+											Type_:"HDD",
+											Size:10,
+											Name:"volume1",
+											Image:"1f46a4a3-3f47-11e6-91c6-52540005ab80",
+											Bus:"VIRTIO",
+											ImagePassword:"test1234",
+											SshKeys: []string{"ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCoLVLHON4BSK3D8L4H79aFo..."},
+										},
+									},
+								},
+							},
+							Nics: &model.Nics{
+								Items: []model.Nic{
+									model.Nic{
+										Properties: model.NicProperties{
+											Name : "nic",
+											Lan : "1",
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	
+dc := CompositeCreateDatacenter(datacenter)
+
+```
+
+
+## How To: Delete Data Center
+
+You will want to exercise a bit of caution here. Removing a data center will destroy all objects contained within that data center -- servers, volumes, snapshots, and so on.
+
+The code to remove a data center is as follows. This example assumes you want to remove previously data center:
+
+```go
+profitbricks.DeleteDatacenter(response.Id)
+```
+
+## How To: Create Server
+
+The server create method has a list of required parameters followed by a hash of optional parameters. The optional parameters are specified within the "options" hash and the variable names match the [REST API](https://devops.profitbricks.com/api/rest/) parameters.
+
+The following example shows you how to create a new server in the data center created above:
+
+```go
+req := profitbricks.Server{
+ 		Properties: profitbricks.ServerProperties{
+ 			Name:  "go01",
+ 			Ram:   1024,
+ 			Cores: 2,
+ 		},
+}
+server := CreateServer(datacenter.Id, req)
+```
+
+## How To: List Available Images
+
+A list of disk and ISO images are available from ProfitBricks for immediate use. These can be easily viewed and selected. The following shows you how to get a list of images. This list represents both CDROM images and HDD images.
+
+```go
+images := profitbricks.ListImages()
+```
+
+This will return a [collection](#Collection) object
+
+## How To: Create Storage Volume
+
+ProfitBricks allows for the creation of multiple storage volumes that can be attached and detached as needed. It is useful to attach an image when creating a storage volume. The storage size is in gigabytes.
+
+```go
+volumerequest := profitbricks.Volume{
+		Properties: profitbricks.VolumeProperties{
+			Size:        1,
+			Name:        "Volume Test",
+			LicenceType: "LINUX",
+			Type:        "HDD",
+		},
+}
+
+storage := CreateVolume(datacenter.Id, volumerequest)
+```
+
+## How To: Update Cores and Memory
+
+ProfitBricks allows users to dynamically update cores, memory, and disk independently of each other. This removes the restriction of needing to upgrade to the next size available size to receive an increase in memory. You can now simply increase the instances memory keeping your costs in-line with your resource needs.
+
+Note: The memory parameter value must be a multiple of 256, e.g. 256, 512, 768, 1024, and so forth.
+
+The following code illustrates how you can update cores and memory:
+
+```go
+serverupdaterequest := profitbricks.ServerProperties{
+	Cores: 1,
+	Ram:   256,
+}
+
+resp := PatchServer(datacenter.Id, server.Id, serverupdaterequest)
+```
+
+## How To: Attach or Detach Storage Volume
+
+ProfitBricks allows for the creation of multiple storage volumes. You can detach and reattach these on the fly. This allows for various scenarios such as re-attaching a failed OS disk to another server for possible recovery or moving a volume to another location and spinning it up.
+
+The following illustrates how you would attach and detach a volume and CDROM to/from a server:
+
+```go
+profitbricks.AttachVolume(datacenter.Id, server.Id, volume.Id)
+profitbricks.AttachCdrom(datacenter.Id, server.Id, images.Items[0].Id)
+
+profitbricks.DetachVolume(datacenter.Id, server.Id, volume.Id)
+profitbricks.DetachCdrom(datacenter.Id, server.Id, images.Items[0].Id)
+```
+
+## How To: List Servers, Volumes, and Data Centers
+
+Go SDK provides standard functions for retrieving a list of volumes, servers, and datacenters.
+
+The following code illustrates how to pull these three list types:
+
+```go
+volumes := profitbricks.ListVolumes(datacenter.Id)
+
+servers := profitbricks.ListServers(datacenter.Id)
+
+datacenters := profitbricks.ListDatacenters()
+```
+
+## Example
+
+```go
+package main
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/profitbricks/profitbricks-sdk-go"
+)
+
+func main() {
+
+	//Sets username and password
+	profitbricks.SetAuth("username", "password")
+	//Sets depth.
+	profitbricks.SetDepth("5")
+
+	dcrequest := profitbricks.Datacenter{
+		Properties: profitbricks.DatacenterProperties{
+			Name:        "example.go3",
+			Description: "description",
+			Location:    "us/lasdev",
+		},
+	}
+
+	datacenter := profitbricks.CreateDatacenter(dcrequest)
+
+	serverrequest := profitbricks.Server{
+		Properties: profitbricks.ServerProperties{
+			Name:  "go01",
+			Ram:   1024,
+			Cores: 2,
+		},
+	}
+	server := profitbricks.CreateServer(datacenter.Id, serverrequest)
+
+	volumerequest := profitbricks.Volume{
+		Properties: profitbricks.VolumeProperties{
+			Size:        1,
+			Name:        "Volume Test",
+			LicenceType: "LINUX",
+			Type:        "HDD",
+		},
+	}
+
+	storage := profitbricks.CreateVolume(datacenter.Id, volumerequest)
+
+	serverupdaterequest := profitbricks.ServerProperties{
+		Name:  "go01renamed",
+		Cores: 1,
+		Ram:   256,
+	}
+
+	profitbricks.PatchServer(datacenter.Id, server.Id, serverupdaterequest)
+	//It takes a moment for a volume to be provisioned so we wait.
+	time.Sleep(60 * time.Second)
+
+	profitbricks.AttachVolume(datacenter.Id, server.Id, storage.Id)
+
+	volumes := profitbricks.ListVolumes(datacenter.Id)
+	fmt.Println(volumes.Items)
+	servers := profitbricks.ListServers(datacenter.Id)
+	fmt.Println(servers.Items)
+	datacenters := profitbricks.ListDatacenters()
+	fmt.Println(datacenters.Items)
+
+	profitbricks.DeleteServer(datacenter.Id, server.Id)
+	profitbricks.DeleteDatacenter(datacenter.Id)
+}
+```
+
+# Support
+You are welcome to contact us with questions or comments at [ProfitBricks DevOps Central](https://devops.profitbricks.com/). Please report any issues via [GitHub's issue tracker](https://github.com/profitbricks/profitbricks-sdk-go/issues).

--- a/vendor/github.com/profitbricks/profitbricks-sdk-go/composite_test.go
+++ b/vendor/github.com/profitbricks/profitbricks-sdk-go/composite_test.go
@@ -1,0 +1,96 @@
+package profitbricks
+
+import (
+	"fmt"
+	"strconv"
+	"testing"
+	"time"
+)
+
+var ipId string
+
+func TestCompositeCreate(t *testing.T) {
+	setupTestEnv()
+
+	datacenter := Datacenter{
+		Properties: DatacenterProperties{
+			Name:     "composite test",
+			Location: location,
+		},
+		Entities: DatacenterEntities{
+			Lans: &Lans{
+				Items: []Lan{
+					Lan{
+						Properties: LanProperties{
+							Public: true,
+						},
+					},
+				},
+			},
+		},
+	}
+
+	dc := CompositeCreateDatacenter(datacenter)
+	dcID = dc.Id
+	waitTillProvisioned(dc.Headers.Get("Location"))
+	SetDepth("5")
+
+	lan_id, _ := strconv.Atoi(dc.Entities.Lans.Items[0].Id)
+	server := Server{
+		Properties: ServerProperties{
+			Name:  "server1",
+			Ram:   2048,
+			Cores: 1,
+		},
+		Entities: &ServerEntities{
+			Volumes: &Volumes{
+				Items: []Volume{
+					Volume{
+						Properties: VolumeProperties{
+							Type:    "HDD",
+							Size:    10,
+							Name:    "volume1",
+							Image:   image,
+							Bus:     "VIRTIO",
+							SshKeys: []string{"ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCoLVLHON4BSK3D8L4H79aFo+0cj7VM2NiRR/K9wrfkK/XiTc7FlEU4Bs8WLZcsIOxbCGWn2zKZmrLaxYlY+/3aJrxDxXYCy8lRUMnqcQ2JCFY6tpZt/DylPhS9L6qYNpJ0F4FlqRsWxsjpF8TDdJi64k2JFJ8TkvX36P2/kqyFfI+N0/axgjhqV3BgNgApvMt9jxWB5gi8LgDpw9b+bHeMS7TrAVDE7bzT86dmfbTugtiME8cIday8YcRb4xAFgRH8XJVOcE3cs390V/dhgCKy1P5+TjQMjKbFIy2LJoxb7bd38kAl1yafZUIhI7F77i7eoRidKV71BpOZsaPEbWUP jasmin@Jasmins-MBP"},
+						},
+					},
+				},
+			},
+			Nics: &Nics{
+				Items: []Nic{
+					Nic{
+						Properties: NicProperties{
+							Name: "nic",
+							Lan:  lan_id,
+						},
+					},
+				},
+			},
+		},
+	}
+
+	server = CreateServer(dcID, server)
+	waitTillProvisioned(server.Headers.Get("Location"))
+
+	for i := 0; i < 10; i++ {
+		request := GetDatacenter(dcID)
+		if request.Metadata.State == "AVAILABLE" {
+			fmt.Println("DC operational")
+			break
+		}
+		time.Sleep(10 * time.Second)
+		i++
+	}
+}
+
+func TestDeleteDC(t *testing.T) {
+	want := 202
+
+	resp := DeleteDatacenter(dcID)
+	if resp.StatusCode != want {
+		t.Errorf(bad_status(want, resp.StatusCode))
+	}
+
+	waitTillProvisioned(resp.Headers.Get("Location"))
+}

--- a/vendor/github.com/profitbricks/profitbricks-sdk-go/config.go
+++ b/vendor/github.com/profitbricks/profitbricks-sdk-go/config.go
@@ -1,0 +1,27 @@
+package profitbricks
+
+// Endpoint is the base url for REST requests.
+var Endpoint = "https://api.profitbricks.com/cloudapi/v3"
+
+//  Username for authentication .
+var Username string
+
+// Password for authentication .
+var Passwd string
+
+// SetEndpoint is used to set the REST Endpoint. Endpoint is declared in config.go
+func SetEndpoint(newendpoint string) string {
+	Endpoint = newendpoint
+	return Endpoint
+}
+
+// SetAuth is used to set Username and Passwd. Username and Passwd are declared in config.go
+
+func SetAuth(u, p string) {
+	Username = u
+	Passwd = p
+}
+
+func SetUserAgent(userAgent string) {
+	AgentHeader = userAgent
+}

--- a/vendor/github.com/profitbricks/profitbricks-sdk-go/config_test.go
+++ b/vendor/github.com/profitbricks/profitbricks-sdk-go/config_test.go
@@ -1,0 +1,57 @@
+package profitbricks
+
+import (
+	"fmt"
+	"os"
+	"strconv"
+	"testing"
+)
+
+// bad_status is the return string for bad status errors
+func bad_status(wanted, got int) string {
+	return " StatusCode is " + strconv.Itoa(got) + " wanted " + strconv.Itoa(wanted)
+}
+
+// Set Username and Password here for Testing.
+/*var username = "jclouds@stackpointcloud.com"
+var passwd = os.Getenv("PB_PASSWORD")*/
+var username = os.Getenv("PROFITBRICKS_USERNAME")
+var passwd = os.Getenv("PROFITBRICKS_PASSWORD")
+var endpoint = os.Getenv("PROFITBRICKS_API_URL")
+var location = "us/las"
+var image = getImageId(location, "ubuntu-16.04", "HDD")
+
+func TestSetAuth(t *testing.T) {
+	fmt.Println("Current Username ", Username)
+	SetAuth(username, passwd)
+	fmt.Println("Applied Username ", Username)
+}
+
+func TestSetEndpoint(t *testing.T) {
+	SetEndpoint(endpoint)
+	fmt.Println("Endpoint is ", Endpoint)
+}
+
+func TestImage(t *testing.T) {
+	fmt.Println("Image ID is:", image)
+}
+
+func TestMain(m *testing.M) {
+	r := m.Run()
+	SetAuth(os.Getenv("PROFITBRICKS_USERNAME"), os.Getenv("PROFITBRICKS_PASSWORD"))
+	os.Exit(r)
+}
+
+// Setup creds for single running tests
+func setupTestEnv() {
+	SetAuth(os.Getenv("PROFITBRICKS_USERNAME"), os.Getenv("PROFITBRICKS_PASSWORD"))
+	SetEndpoint(os.Getenv("PROFITBRICKS_API_URL"))
+}
+
+func TestSetUserAgent(t *testing.T) {
+	SetUserAgent("blah")
+
+	if AgentHeader != "blah" {
+		t.Errorf("AgentHeader not equal %s", "blah")
+	}
+}

--- a/vendor/github.com/profitbricks/profitbricks-sdk-go/datacenter.go
+++ b/vendor/github.com/profitbricks/profitbricks-sdk-go/datacenter.go
@@ -1,0 +1,121 @@
+package profitbricks
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"time"
+)
+
+type Datacenter struct {
+	Id         string                     `json:"id,omitempty"`
+	Type_      string                     `json:"type,omitempty"`
+	Href       string                     `json:"href,omitempty"`
+	Metadata   *DatacenterElementMetadata `json:"metadata,omitempty"`
+	Properties DatacenterProperties       `json:"properties,omitempty"`
+	Entities   DatacenterEntities         `json:"entities,omitempty"`
+	Response   string                     `json:"Response,omitempty"`
+	Headers    *http.Header               `json:"headers,omitempty"`
+	StatusCode int                        `json:"headers,omitempty"`
+}
+
+type DatacenterElementMetadata struct {
+	CreatedDate      time.Time `json:"createdDate,omitempty"`
+	CreatedBy        string    `json:"createdBy,omitempty"`
+	Etag             string    `json:"etag,omitempty"`
+	LastModifiedDate time.Time `json:"lastModifiedDate,omitempty"`
+	LastModifiedBy   string    `json:"lastModifiedBy,omitempty"`
+	State            string    `json:"state,omitempty"`
+}
+
+type DatacenterProperties struct {
+	Name        string `json:"name,omitempty"`
+	Description string `json:"description,omitempty"`
+	Location    string `json:"location,omitempty"`
+	Version     int32  `json:"version,omitempty"`
+}
+
+type DatacenterEntities struct {
+	Servers       *Servers       `json:"servers,omitempty"`
+	Volumes       *Volumes       `json:"volumes,omitempty"`
+	Loadbalancers *Loadbalancers `json:"loadbalancers,omitempty"`
+	Lans          *Lans          `json:"lans,omitempty"`
+}
+
+type Datacenters struct {
+	Id         string       `json:"id,omitempty"`
+	Type_      string       `json:"type,omitempty"`
+	Href       string       `json:"href,omitempty"`
+	Items      []Datacenter `json:"items,omitempty"`
+	Response   string       `json:"Response,omitempty"`
+	Headers    *http.Header `json:"headers,omitempty"`
+	StatusCode int          `json:"headers,omitempty"`
+}
+
+func ListDatacenters() Datacenters {
+	path := dc_col_path()
+	url := mk_url(path) + `?depth=` + Depth
+	req, _ := http.NewRequest("GET", url, nil)
+	req.Header.Add("Content-Type", FullHeader)
+	resp := do(req)
+	return toDataCenters(resp)
+}
+
+func CreateDatacenter(dc Datacenter) Datacenter {
+	obj, _ := json.Marshal(dc)
+	path := dc_col_path()
+	url := mk_url(path)
+	req, _ := http.NewRequest("POST", url, bytes.NewBuffer(obj))
+	req.Header.Add("Content-Type", FullHeader)
+
+	return toDataCenter(do(req))
+}
+
+func CompositeCreateDatacenter(datacenter Datacenter) Datacenter {
+	obj, _ := json.Marshal(datacenter)
+	path := dc_col_path()
+	url := mk_url(path) + `?depth=` + Depth
+	req, _ := http.NewRequest("POST", url, bytes.NewBuffer(obj))
+	req.Header.Add("Content-Type", FullHeader)
+	return toDataCenter(do(req))
+}
+
+func GetDatacenter(dcid string) Datacenter {
+	path := dc_path(dcid)
+	url := mk_url(path) + `?depth=` + Depth
+	req, _ := http.NewRequest("GET", url, nil)
+	req.Header.Add("Content-Type", FullHeader)
+	return toDataCenter(do(req))
+}
+
+func PatchDatacenter(dcid string, obj DatacenterProperties) Datacenter {
+	jason_patch := []byte(MkJson(obj))
+	path := dc_path(dcid)
+	url := mk_url(path) + `?depth=` + Depth
+	req, _ := http.NewRequest("PATCH", url, bytes.NewBuffer(jason_patch))
+	req.Header.Add("Content-Type", PatchHeader)
+	return toDataCenter(do(req))
+}
+
+func DeleteDatacenter(dcid string) Resp {
+	path := dc_path(dcid)
+	return is_delete(path)
+}
+
+func toDataCenter(resp Resp) Datacenter {
+	var dc Datacenter
+	json.Unmarshal(resp.Body, &dc)
+	dc.Response = string(resp.Body)
+	dc.Headers = &resp.Headers
+	dc.StatusCode = resp.StatusCode
+	return dc
+}
+
+func toDataCenters(resp Resp) Datacenters {
+	var col Datacenters
+	json.Unmarshal(resp.Body, &col)
+	col.Response = string(resp.Body)
+	col.Headers = &resp.Headers
+	col.StatusCode = resp.StatusCode
+	return col
+}

--- a/vendor/github.com/profitbricks/profitbricks-sdk-go/datacenter_test.go
+++ b/vendor/github.com/profitbricks/profitbricks-sdk-go/datacenter_test.go
@@ -1,0 +1,65 @@
+package profitbricks
+
+import (
+	"testing"
+)
+
+var dcID string
+
+func TestListDatacenters(t *testing.T) {
+	setupTestEnv()
+	want := 200
+
+	resp := ListDatacenters()
+
+	if resp.StatusCode != want {
+		t.Errorf(bad_status(want, resp.StatusCode))
+	}
+}
+
+func TestCreateDatacenter(t *testing.T) {
+	want := 202
+	var obj = Datacenter{
+		Properties: DatacenterProperties{
+			Name:        "GO SDK",
+			Description: "description",
+			Location:    location,
+		},
+	}
+	resp := CompositeCreateDatacenter(obj)
+	dcID = resp.Id
+
+	if resp.StatusCode != want {
+		t.Errorf(bad_status(want, resp.StatusCode))
+	}
+}
+func TestGetDatacenter(t *testing.T) {
+	want := 200
+	resp := GetDatacenter(dcID)
+	if resp.StatusCode != want {
+		t.Errorf(bad_status(want, resp.StatusCode))
+	}
+}
+
+func TestPatchDatacenter(t *testing.T) {
+	want := 202
+	newName := "Renamed DC"
+	obj := DatacenterProperties{Name: newName} //map[string]string{"name": "Renamed DC"}
+
+	resp := PatchDatacenter(dcID, obj)
+	if resp.StatusCode != want {
+		t.Errorf(bad_status(want, resp.StatusCode))
+	}
+	if resp.Properties.Name != newName {
+		t.Errorf("Not updated")
+	}
+
+}
+
+func TestDeleteDatacenter(t *testing.T) {
+	want := 202
+	resp := DeleteDatacenter(dcID)
+	if resp.StatusCode != want {
+		t.Errorf(bad_status(want, resp.StatusCode))
+	}
+}

--- a/vendor/github.com/profitbricks/profitbricks-sdk-go/doc.go
+++ b/vendor/github.com/profitbricks/profitbricks-sdk-go/doc.go
@@ -1,0 +1,6 @@
+/*
+Package profitbricks is a client library for interacting with Profitbricks RESTful APIs.
+
+
+*/
+package profitbricks

--- a/vendor/github.com/profitbricks/profitbricks-sdk-go/example/example.go
+++ b/vendor/github.com/profitbricks/profitbricks-sdk-go/example/example.go
@@ -1,0 +1,68 @@
+package main
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/profitbricks/profitbricks-sdk-go"
+)
+
+func main() {
+
+	//Sets username and password
+	profitbricks.SetAuth("username", "password")
+	//Sets depth.
+	profitbricks.SetDepth("5")
+
+	dcrequest := profitbricks.Datacenter{
+		Properties: profitbricks.DatacenterProperties{
+			Name:        "example.go3",
+			Description: "description",
+			Location:    "us/lasdev",
+		},
+	}
+
+	datacenter := profitbricks.CreateDatacenter(dcrequest)
+
+	serverrequest := profitbricks.Server{
+		Properties: profitbricks.ServerProperties{
+			Name:  "go01",
+			Ram:   1024,
+			Cores: 2,
+		},
+	}
+	server := profitbricks.CreateServer(datacenter.Id, serverrequest)
+
+	volumerequest := profitbricks.Volume{
+		Properties: profitbricks.VolumeProperties{
+			Size:        1,
+			Name:        "Volume Test",
+			LicenceType: "LINUX",
+			Type:        "HDD",
+		},
+	}
+
+	storage := profitbricks.CreateVolume(datacenter.Id, volumerequest)
+
+	serverupdaterequest := profitbricks.ServerProperties{
+		Name:  "go01renamed",
+		Cores: 1,
+		Ram:   256,
+	}
+
+	profitbricks.PatchServer(datacenter.Id, server.Id, serverupdaterequest)
+	//It takes a moment for a volume to be provisioned so we wait.
+	time.Sleep(60 * time.Second)
+
+	profitbricks.AttachVolume(datacenter.Id, server.Id, storage.Id)
+
+	volumes := profitbricks.ListVolumes(datacenter.Id)
+	fmt.Println(volumes.Items)
+	servers := profitbricks.ListServers(datacenter.Id)
+	fmt.Println(servers.Items)
+	datacenters := profitbricks.ListDatacenters()
+	fmt.Println(datacenters.Items)
+
+	profitbricks.DeleteServer(datacenter.Id, server.Id)
+	profitbricks.DeleteDatacenter(datacenter.Id)
+}

--- a/vendor/github.com/profitbricks/profitbricks-sdk-go/firewallrule.go
+++ b/vendor/github.com/profitbricks/profitbricks-sdk-go/firewallrule.go
@@ -1,0 +1,99 @@
+package profitbricks
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+)
+
+type FirewallRule struct {
+	Id         string                     `json:"id,omitempty"`
+	Type_      string                     `json:"type,omitempty"`
+	Href       string                     `json:"href,omitempty"`
+	Metadata   *DatacenterElementMetadata `json:"metadata,omitempty"`
+	Properties FirewallruleProperties     `json:"properties,omitempty"`
+	Response   string                     `json:"Response,omitempty"`
+	Headers    *http.Header               `json:"headers,omitempty"`
+	StatusCode int                        `json:"headers,omitempty"`
+}
+
+type FirewallruleProperties struct {
+	Name           string `json:"name,omitempty"`
+	Protocol       string `json:"protocol,omitempty"`
+	SourceMac      string `json:"sourceMac,omitempty"`
+	SourceIp       string `json:"sourceIp,omitempty"`
+	TargetIp       string `json:"targetIp,omitempty"`
+	IcmpCode       interface{}    `json:"icmpCode,omitempty"`
+	IcmpType       interface{}    `json:"icmpType,omitempty"`
+	PortRangeStart interface{}    `json:"portRangeStart,omitempty"`
+	PortRangeEnd   interface{}    `json:"portRangeEnd,omitempty"`
+}
+
+type FirewallRules struct {
+	Id         string         `json:"id,omitempty"`
+	Type_      string         `json:"type,omitempty"`
+	Href       string         `json:"href,omitempty"`
+	Items      []FirewallRule `json:"items,omitempty"`
+	Response   string         `json:"Response,omitempty"`
+	Headers    *http.Header   `json:"headers,omitempty"`
+	StatusCode int            `json:"headers,omitempty"`
+}
+
+func ListFirewallRules(dcId string, serverid string, nicId string) FirewallRules {
+	path := fwrule_col_path(dcId, serverid, nicId)
+	url := mk_url(path) + `?depth=` + Depth
+	req, _ := http.NewRequest("GET", url, nil)
+	req.Header.Add("Content-Type", FullHeader)
+	resp := do(req)
+	return toFirewallRules(resp)
+}
+
+func GetFirewallRule(dcid string, srvid string, nicId string, fwId string) FirewallRule {
+	path := fwrule_path(dcid, srvid, nicId, fwId)
+	url := mk_url(path) + `?depth=` + Depth
+	req, _ := http.NewRequest("GET", url, nil)
+	req.Header.Add("Content-Type", FullHeader)
+	resp := do(req)
+	return toFirewallRule(resp)
+}
+
+func CreateFirewallRule(dcid string, srvid string, nicId string, fw FirewallRule) FirewallRule {
+	path := fwrule_col_path(dcid, srvid, nicId)
+	url := mk_url(path) + `?depth=` + Depth
+	obj, _ := json.Marshal(fw)
+	req, _ := http.NewRequest("POST", url, bytes.NewBuffer(obj))
+	req.Header.Add("Content-Type", FullHeader)
+	return toFirewallRule(do(req))
+}
+
+func PatchFirewallRule(dcid string, srvid string, nicId string, fwId string, obj FirewallruleProperties) FirewallRule {
+	jason_patch := []byte(MkJson(obj))
+	path := fwrule_path(dcid, srvid, nicId, fwId)
+	url := mk_url(path) + `?depth=` + Depth
+	req, _ := http.NewRequest("PATCH", url, bytes.NewBuffer(jason_patch))
+	req.Header.Add("Content-Type", PatchHeader)
+	return toFirewallRule(do(req))
+}
+
+func DeleteFirewallRule(dcid string, srvid string, nicId string, fwId string) Resp {
+	path := fwrule_path(dcid, srvid, nicId, fwId)
+	return is_delete(path)
+}
+
+func toFirewallRule(resp Resp) FirewallRule {
+	var dc FirewallRule
+	json.Unmarshal(resp.Body, &dc)
+	dc.Response = string(resp.Body)
+	dc.Headers = &resp.Headers
+	dc.StatusCode = resp.StatusCode
+	return dc
+}
+
+func toFirewallRules(resp Resp) FirewallRules {
+	var col FirewallRules
+	json.Unmarshal(resp.Body, &col)
+	col.Response = string(resp.Body)
+	col.Headers = &resp.Headers
+	col.StatusCode = resp.StatusCode
+	return col
+}

--- a/vendor/github.com/profitbricks/profitbricks-sdk-go/firewallrule_test.go
+++ b/vendor/github.com/profitbricks/profitbricks-sdk-go/firewallrule_test.go
@@ -1,0 +1,118 @@
+package profitbricks
+
+import (
+	"fmt"
+	"testing"
+)
+
+var fwId string
+
+func setup() {
+	datacenter := Datacenter{
+		Properties: DatacenterProperties{
+			Name:     "composite test",
+			Location: location,
+		},
+		Entities: DatacenterEntities{
+			Servers: &Servers{
+				Items: []Server{
+					Server{
+						Properties: ServerProperties{
+							Name:  "server1",
+							Ram:   2048,
+							Cores: 1,
+						},
+						Entities: &ServerEntities{
+							Nics: &Nics{
+								Items: []Nic{
+									Nic{
+										Properties: NicProperties{
+											Name: "nic",
+											Lan:  1,
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	datacenter = CompositeCreateDatacenter(datacenter)
+	waitTillProvisioned(datacenter.Headers.Get("Location"))
+
+	dcID = datacenter.Id
+	srv_srvid = datacenter.Entities.Servers.Items[0].Id
+	nicid = datacenter.Entities.Servers.Items[0].Entities.Nics.Items[0].Id
+}
+func TestCreateFirewallRule(t *testing.T) {
+	setupTestEnv()
+	want := 202
+	setup()
+
+	fw := FirewallRule{
+		Properties: FirewallruleProperties{
+			Name:     "firewallrule",
+			Protocol: "TCP",
+		},
+	}
+
+	fw = CreateFirewallRule(dcID, srv_srvid, nicid, fw)
+
+	waitTillProvisioned(fw.Headers.Get("Location"))
+
+	if fw.StatusCode != want {
+		t.Error(fw.Response)
+		t.Errorf(bad_status(want, fw.StatusCode))
+	}
+	fwId = fw.Id
+}
+
+func TestGetFirewallRule(t *testing.T) {
+	want := 200
+
+	fw := GetFirewallRule(dcID, srv_srvid, nicid, fwId)
+	if fw.StatusCode != want {
+		t.Error(fw.Response)
+		t.Errorf(bad_status(want, fw.StatusCode))
+	}
+}
+
+func TestListFirewallRules(t *testing.T) {
+	want := 200
+	fws := ListFirewallRules(dcID, srv_srvid, nicid)
+	if fws.StatusCode != want {
+		t.Error(fws.Response)
+		t.Errorf(bad_status(want, fws.StatusCode))
+	}
+}
+
+func TestPatchFirewallRule(t *testing.T) {
+	want := 202
+	props := FirewallruleProperties{
+		Name: "updated",
+	}
+	fw := PatchFirewallRule(dcID, srv_srvid, nicid, fwId, props)
+	if fw.StatusCode != want {
+		t.Error(fw.Response)
+		t.Errorf(bad_status(want, fw.StatusCode))
+	}
+
+	if fw.Properties.Name == "updated" {
+		fmt.Println("Test succeeded")
+	}
+}
+
+func TestDeleteFirewallRule(t *testing.T) {
+	want := 202
+	resp := DeleteFirewallRule(dcID, srv_srvid, nicid, fwId)
+
+	if resp.StatusCode != want {
+		t.Error(string(resp.Body))
+		t.Errorf(bad_status(want, resp.StatusCode))
+	}
+
+	DeleteDatacenter(dcID)
+}

--- a/vendor/github.com/profitbricks/profitbricks-sdk-go/image.go
+++ b/vendor/github.com/profitbricks/profitbricks-sdk-go/image.go
@@ -1,0 +1,98 @@
+package profitbricks
+
+import (
+	"encoding/json"
+	"net/http"
+)
+
+type Image struct {
+	Id         string                     `json:"id,omitempty"`
+	Type       string                     `json:"type,omitempty"`
+	Href       string                     `json:"href,omitempty"`
+	Metadata   *DatacenterElementMetadata `json:"metadata,omitempty"`
+	Properties ImageProperties            `json:"properties,omitempty"`
+	Response   string                     `json:"Response,omitempty"`
+	Headers    *http.Header               `json:"headers,omitempty"`
+	StatusCode int                        `json:"headers,omitempty"`
+}
+
+type ImageProperties struct {
+	Name                string       `json:"name,omitempty"`
+	Description         string       `json:"description,omitempty"`
+	Location            string       `json:"location,omitempty"`
+	Size                int          `json:"size,omitempty"`
+	CpuHotPlug          bool         `json:"cpuHotPlug,omitempty"`
+	CpuHotUnplug        bool         `json:"cpuHotUnplug,omitempty"`
+	RamHotPlug          bool         `json:"ramHotPlug,omitempty"`
+	RamHotUnplug        bool         `json:"ramHotUnplug,omitempty"`
+	NicHotPlug          bool         `json:"nicHotPlug,omitempty"`
+	NicHotUnplug        bool         `json:"nicHotUnplug,omitempty"`
+	DiscVirtioHotPlug   bool         `json:"discVirtioHotPlug,omitempty"`
+	DiscVirtioHotUnplug bool         `json:"discVirtioHotUnplug,omitempty"`
+	DiscScsiHotPlug     bool         `json:"discScsiHotPlug,omitempty"`
+	DiscScsiHotUnplug   bool         `json:"discScsiHotUnplug,omitempty"`
+	LicenceType         string       `json:"licenceType,omitempty"`
+	ImageType           string       `json:"imageType,omitempty"`
+	Public              bool         `json:"public,omitempty"`
+	Response            string       `json:"Response,omitempty"`
+	Headers             *http.Header `json:"headers,omitempty"`
+	StatusCode          int          `json:"headers,omitempty"`
+}
+
+type Images struct {
+	Id         string       `json:"id,omitempty"`
+	Type_      string       `json:"type,omitempty"`
+	Href       string       `json:"href,omitempty"`
+	Items      []Image      `json:"items,omitempty"`
+	Response   string       `json:"Response,omitempty"`
+	Headers    *http.Header `json:"headers,omitempty"`
+	StatusCode int          `json:"headers,omitempty"`
+}
+
+type Cdroms struct {
+	Id         string       `json:"id,omitempty"`
+	Type_      string       `json:"type,omitempty"`
+	Href       string       `json:"href,omitempty"`
+	Items      []Image      `json:"items,omitempty"`
+	Response   string       `json:"Response,omitempty"`
+	Headers    *http.Header `json:"headers,omitempty"`
+	StatusCode int          `json:"headers,omitempty"`
+}
+
+// ListImages returns an Collection struct
+func ListImages() Images {
+	path := image_col_path()
+	url := mk_url(path) + `?depth=` + Depth
+	req, _ := http.NewRequest("GET", url, nil)
+	req.Header.Add("Content-Type", FullHeader)
+	resp := do(req)
+	return toImages(resp)
+}
+
+// GetImage returns an Instance struct where id ==imageid
+func GetImage(imageid string) Image {
+	path := image_path(imageid)
+	url := mk_url(path) + `?depth=` + Depth
+	req, _ := http.NewRequest("GET", url, nil)
+	req.Header.Add("Content-Type", FullHeader)
+	resp := do(req)
+	return toImage(resp)
+}
+
+func toImage(resp Resp) Image {
+	var image Image
+	json.Unmarshal(resp.Body, &image)
+	image.Response = string(resp.Body)
+	image.Headers = &resp.Headers
+	image.StatusCode = resp.StatusCode
+	return image
+}
+
+func toImages(resp Resp) Images {
+	var col Images
+	json.Unmarshal(resp.Body, &col)
+	col.Response = string(resp.Body)
+	col.Headers = &resp.Headers
+	col.StatusCode = resp.StatusCode
+	return col
+}

--- a/vendor/github.com/profitbricks/profitbricks-sdk-go/image_test.go
+++ b/vendor/github.com/profitbricks/profitbricks-sdk-go/image_test.go
@@ -1,0 +1,33 @@
+// image_test.go
+
+package profitbricks
+
+import (
+	"fmt"
+	"testing"
+)
+
+var imgid string
+
+func TestListImages(t *testing.T) {
+	setupTestEnv()
+	want := 200
+	resp := ListImages()
+
+	if resp.StatusCode != want {
+		t.Errorf(bad_status(want, resp.StatusCode))
+		t.Errorf(resp.Response)
+	}
+}
+
+func TestGetImage(t *testing.T) {
+	want := 200
+	resp := GetImage(imgid)
+
+	if resp.StatusCode != want {
+		if resp.StatusCode == 403 {
+			fmt.Println(bad_status(want, resp.StatusCode))
+			fmt.Println("This error might be due to user's permission level ")
+		}
+	}
+}

--- a/vendor/github.com/profitbricks/profitbricks-sdk-go/ipblock.go
+++ b/vendor/github.com/profitbricks/profitbricks-sdk-go/ipblock.go
@@ -1,0 +1,82 @@
+package profitbricks
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+)
+
+type IpBlock struct {
+	Id         string                     `json:"id,omitempty"`
+	Type_      string                     `json:"type,omitempty"`
+	Href       string                     `json:"href,omitempty"`
+	Metadata   *DatacenterElementMetadata `json:"metadata,omitempty"`
+	Properties IpBlockProperties          `json:"properties,omitempty"`
+	Response   string                     `json:"Response,omitempty"`
+	Headers    *http.Header               `json:"headers,omitempty"`
+	StatusCode int                        `json:"headers,omitempty"`
+}
+
+type IpBlockProperties struct {
+	Ips      []string `json:"ips,omitempty"`
+	Location string   `json:"location,omitempty"`
+	Size     int      `json:"size,omitempty"`
+}
+
+type IpBlocks struct {
+	Id         string       `json:"id,omitempty"`
+	Type_      string       `json:"type,omitempty"`
+	Href       string       `json:"href,omitempty"`
+	Items      []IpBlock    `json:"items,omitempty"`
+	Response   string       `json:"Response,omitempty"`
+	Headers    *http.Header `json:"headers,omitempty"`
+	StatusCode int          `json:"headers,omitempty"`
+}
+
+// ListIpBlocks
+func ListIpBlocks() IpBlocks {
+	path := ipblock_col_path()
+	url := mk_url(path) + `?depth=` + Depth
+	req, _ := http.NewRequest("GET", url, nil)
+	req.Header.Add("Content-Type", FullHeader)
+	return toIpBlocks(do(req))
+}
+
+func ReserveIpBlock(request IpBlock) IpBlock {
+	obj, _ := json.Marshal(request)
+	path := ipblock_col_path()
+	url := mk_url(path)
+	req, _ := http.NewRequest("POST", url, bytes.NewBuffer(obj))
+	req.Header.Add("Content-Type", FullHeader)
+	return toIpBlock(do(req))
+}
+func GetIpBlock(ipblockid string) IpBlock {
+	path := ipblock_path(ipblockid)
+	url := mk_url(path) + `?depth=` + Depth
+	req, _ := http.NewRequest("GET", url, nil)
+	req.Header.Add("Content-Type", FullHeader)
+	return toIpBlock(do(req))
+}
+
+func ReleaseIpBlock(ipblockid string) Resp {
+	path := ipblock_path(ipblockid)
+	return is_delete(path)
+}
+
+func toIpBlock(resp Resp) IpBlock {
+	var obj IpBlock
+	json.Unmarshal(resp.Body, &obj)
+	obj.Response = string(resp.Body)
+	obj.Headers = &resp.Headers
+	obj.StatusCode = resp.StatusCode
+	return obj
+}
+
+func toIpBlocks(resp Resp) IpBlocks {
+	var col IpBlocks
+	json.Unmarshal(resp.Body, &col)
+	col.Response = string(resp.Body)
+	col.Headers = &resp.Headers
+	col.StatusCode = resp.StatusCode
+	return col
+}

--- a/vendor/github.com/profitbricks/profitbricks-sdk-go/ipblock_test.go
+++ b/vendor/github.com/profitbricks/profitbricks-sdk-go/ipblock_test.go
@@ -1,0 +1,47 @@
+// ipblock_test.go
+package profitbricks
+
+import "testing"
+
+var ipblkid string
+
+func TestListIpBlocks(t *testing.T) {
+	setupTestEnv()
+	want := 200
+	resp := ListIpBlocks()
+	if resp.StatusCode != want {
+		t.Errorf(bad_status(want, resp.StatusCode))
+	}
+}
+
+func TestReserveIpBlock(t *testing.T) {
+	want := 202
+	var obj = IpBlock{
+		Properties: IpBlockProperties{
+			Size:     1,
+			Location: "us/las",
+		},
+	}
+
+	resp := ReserveIpBlock(obj)
+	ipblkid = resp.Id
+	if resp.StatusCode != want {
+		t.Errorf(bad_status(want, resp.StatusCode))
+	}
+}
+
+func TestGetIpBlock(t *testing.T) {
+	want := 200
+	resp := GetIpBlock(ipblkid)
+	if resp.StatusCode != want {
+		t.Errorf(bad_status(want, resp.StatusCode))
+	}
+}
+
+func TestReleaseIpBlock(t *testing.T) {
+	want := 202
+	resp := ReleaseIpBlock(ipblkid)
+	if resp.StatusCode != want {
+		t.Errorf(bad_status(want, resp.StatusCode))
+	}
+}

--- a/vendor/github.com/profitbricks/profitbricks-sdk-go/lan.go
+++ b/vendor/github.com/profitbricks/profitbricks-sdk-go/lan.go
@@ -1,0 +1,109 @@
+package profitbricks
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+)
+
+type Lan struct {
+	Id         string                     `json:"id,omitempty"`
+	Type_      string                     `json:"type,omitempty"`
+	Href       string                     `json:"href,omitempty"`
+	Metadata   *DatacenterElementMetadata `json:"metadata,omitempty"`
+	Properties LanProperties              `json:"properties,omitempty"`
+	Entities   *LanEntities               `json:"entities,omitempty"`
+	Response   string                     `json:"Response,omitempty"`
+	Headers    *http.Header               `json:"headers,omitempty"`
+	StatusCode int                        `json:"headers,omitempty"`
+}
+
+type LanProperties struct {
+	Name   string `json:"name,omitempty"`
+	Public interface{}   `json:"public,omitempty"`
+}
+
+type LanEntities struct {
+	Nics *LanNics `json:"nics,omitempty"`
+}
+
+type LanNics struct {
+	Id    string `json:"id,omitempty"`
+	Type_ string `json:"type,omitempty"`
+	Href  string `json:"href,omitempty"`
+	Items []Nic  `json:"items,omitempty"`
+}
+
+type Lans struct {
+	Id         string       `json:"id,omitempty"`
+	Type_      string       `json:"type,omitempty"`
+	Href       string       `json:"href,omitempty"`
+	Items      []Lan        `json:"items,omitempty"`
+	Response   string       `json:"Response,omitempty"`
+	Headers    *http.Header `json:"headers,omitempty"`
+	StatusCode int          `json:"headers,omitempty"`
+}
+
+// ListLan returns a Collection for lans in the Datacenter
+func ListLans(dcid string) Lans {
+	path := lan_col_path(dcid)
+	url := mk_url(path) + `?depth=` + Depth
+	req, _ := http.NewRequest("GET", url, nil)
+	req.Header.Add("Content-Type", FullHeader)
+	return toLans(do(req))
+}
+
+// CreateLan creates a lan in the datacenter
+// from a jason []byte and returns a Instance struct
+func CreateLan(dcid string, request Lan) Lan {
+	obj, _ := json.Marshal(request)
+	path := lan_col_path(dcid)
+	url := mk_url(path)
+	req, _ := http.NewRequest("POST", url, bytes.NewBuffer(obj))
+	req.Header.Add("Content-Type", FullHeader)
+	return toLan(do(req))
+}
+
+// GetLan pulls data for the lan where id = lanid returns an Instance struct
+func GetLan(dcid, lanid string) Lan {
+	path := lan_path(dcid, lanid)
+	url := mk_url(path) + `?depth=` + Depth
+	req, _ := http.NewRequest("GET", url, nil)
+	req.Header.Add("Content-Type", FullHeader)
+	return toLan(do(req))
+}
+
+// PatchLan does a partial update to a lan using json from []byte jason
+// returns a Instance struct
+func PatchLan(dcid string, lanid string, obj LanProperties) Lan {
+	jason := []byte(MkJson(obj))
+	path := lan_path(dcid, lanid)
+	url := mk_url(path)
+	req, _ := http.NewRequest("PATCH", url, bytes.NewBuffer(jason))
+	req.Header.Add("Content-Type", PatchHeader)
+	return toLan(do(req))
+}
+
+// DeleteLan deletes a lan where id == lanid
+func DeleteLan(dcid, lanid string) Resp {
+	path := lan_path(dcid, lanid)
+	return is_delete(path)
+}
+
+func toLan(resp Resp) Lan {
+	var lan Lan
+	json.Unmarshal(resp.Body, &lan)
+	lan.Response = string(resp.Body)
+	lan.Headers = &resp.Headers
+	lan.StatusCode = resp.StatusCode
+	return lan
+}
+
+func toLans(resp Resp) Lans {
+	var col Lans
+	json.Unmarshal(resp.Body, &col)
+	col.Response = string(resp.Body)
+	col.Headers = &resp.Headers
+	col.StatusCode = resp.StatusCode
+	return col
+}

--- a/vendor/github.com/profitbricks/profitbricks-sdk-go/lan_test.go
+++ b/vendor/github.com/profitbricks/profitbricks-sdk-go/lan_test.go
@@ -1,0 +1,68 @@
+// lan_test.go
+package profitbricks
+
+import (
+	"testing"
+)
+
+var lan_dcid string
+var lanid string
+
+func TestCreateLan(t *testing.T) {
+	setupTestEnv()
+	lan_dcid = mkdcid("GO SDK LAN DC")
+	want := 202
+	var request = Lan{
+		Properties: LanProperties{
+			Public: true,
+			Name:   "Lan Test",
+		},
+	}
+	lan := CreateLan(lan_dcid, request)
+	waitTillProvisioned(lan.Headers.Get("Location"))
+	lanid = lan.Id
+	if lan.StatusCode != want {
+		t.Errorf(bad_status(want, lan.StatusCode))
+	}
+}
+
+func TestListLans(t *testing.T) {
+	want := 200
+	lans := ListLans(lan_dcid)
+
+	if lans.StatusCode != want {
+		t.Errorf(bad_status(want, lans.StatusCode))
+	}
+}
+
+func TestGetLan(t *testing.T) {
+	want := 200
+	lan := GetLan(lan_dcid, lanid)
+
+	if lan.StatusCode != want {
+		t.Errorf(bad_status(want, lan.StatusCode))
+	}
+}
+
+func TestPatchLan(t *testing.T) {
+	want := 202
+	obj := LanProperties{Public: false}
+
+	lan := PatchLan(lan_dcid, lanid, obj)
+	if lan.StatusCode != want {
+		t.Errorf(bad_status(want, lan.StatusCode))
+	}
+}
+
+func TestDeleteLan(t *testing.T) {
+	want := 202
+	resp := DeleteLan(lan_dcid, lanid)
+	if resp.StatusCode != want {
+		t.Errorf(bad_status(want, resp.StatusCode))
+	}
+}
+
+func TestLanCleanup(t *testing.T) {
+	DeleteLan(lan_dcid, lanid)
+	DeleteDatacenter(lan_dcid)
+}

--- a/vendor/github.com/profitbricks/profitbricks-sdk-go/loadbalancer.go
+++ b/vendor/github.com/profitbricks/profitbricks-sdk-go/loadbalancer.go
@@ -1,0 +1,145 @@
+package profitbricks
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+)
+
+type Loadbalancer struct {
+	Id         string                     `json:"id,omitempty"`
+	Type_      string                     `json:"type,omitempty"`
+	Href       string                     `json:"href,omitempty"`
+	Metadata   *DatacenterElementMetadata `json:"metadata,omitempty"`
+	Properties LoadbalancerProperties     `json:"properties,omitempty"`
+	Entities   LoadbalancerEntities       `json:"entities,omitempty"`
+	Response   string                     `json:"Response,omitempty"`
+	Headers    *http.Header               `json:"headers,omitempty"`
+	StatusCode int                        `json:"headers,omitempty"`
+}
+
+type LoadbalancerProperties struct {
+	Name string `json:"name,omitempty"`
+	Ip   string `json:"ip,omitempty"`
+	Dhcp bool   `json:"dhcp,omitempty"`
+}
+
+type LoadbalancerEntities struct {
+	Balancednics *BalancedNics `json:"balancednics,omitempty"`
+}
+
+type BalancedNics struct {
+	Id    string `json:"id,omitempty"`
+	Type_ string `json:"type,omitempty"`
+	Href  string `json:"href,omitempty"`
+	Items []Nic  `json:"items,omitempty"`
+}
+
+type Loadbalancers struct {
+	Id    string         `json:"id,omitempty"`
+	Type_ string         `json:"type,omitempty"`
+	Href  string         `json:"href,omitempty"`
+	Items []Loadbalancer `json:"items,omitempty"`
+
+	Response   string       `json:"Response,omitempty"`
+	Headers    *http.Header `json:"headers,omitempty"`
+	StatusCode int          `json:"headers,omitempty"`
+}
+
+type LoablanacerCreateRequest struct {
+	LoadbalancerProperties `json:"properties"`
+}
+
+// Listloadbalancers returns a Collection struct
+// for loadbalancers in the Datacenter
+func ListLoadbalancers(dcid string) Loadbalancers {
+	path := lbal_col_path(dcid)
+	url := mk_url(path) + `?depth=` + Depth
+	req, _ := http.NewRequest("GET", url, nil)
+	req.Header.Add("Content-Type", FullHeader)
+	return toLoadbalancers(do(req))
+}
+
+// Createloadbalancer creates a loadbalancer in the datacenter
+//from a jason []byte and returns a Instance struct
+func CreateLoadbalancer(dcid string, request Loadbalancer) Loadbalancer {
+	obj, _ := json.Marshal(request)
+	path := lbal_col_path(dcid)
+	url := mk_url(path)
+	req, _ := http.NewRequest("POST", url, bytes.NewBuffer(obj))
+	req.Header.Add("Content-Type", FullHeader)
+	return toLoadbalancer(do(req))
+}
+
+// GetLoadbalancer pulls data for the Loadbalancer
+// where id = lbalid returns a Instance struct
+func GetLoadbalancer(dcid, lbalid string) Loadbalancer {
+	path := lbal_path(dcid, lbalid)
+	url := mk_url(path) + `?depth=` + Depth
+	req, _ := http.NewRequest("GET", url, nil)
+	req.Header.Add("Content-Type", FullHeader)
+	return toLoadbalancer(do(req))
+}
+
+func PatchLoadbalancer(dcid string, lbalid string, obj LoadbalancerProperties) Loadbalancer {
+	jason := []byte(MkJson(obj))
+	path := lbal_path(dcid, lbalid)
+	url := mk_url(path)
+	req, _ := http.NewRequest("PATCH", url, bytes.NewBuffer(jason))
+	req.Header.Add("Content-Type", PatchHeader)
+	return toLoadbalancer(do(req))
+}
+
+func DeleteLoadbalancer(dcid, lbalid string) Resp {
+	path := lbal_path(dcid, lbalid)
+	return is_delete(path)
+}
+
+func ListBalancedNics(dcid, lbalid string) Nics {
+	path := balnic_col_path(dcid, lbalid)
+	url := mk_url(path) + `?depth=` + Depth
+	req, _ := http.NewRequest("GET", url, nil)
+	req.Header.Add("Content-Type", FullHeader)
+	return toNics(do(req))
+}
+
+func AssociateNic(dcid string, lbalid string, nicid string) Nic {
+	sm := map[string]string{"id": nicid}
+	jason := []byte(MkJson(sm))
+	path := balnic_col_path(dcid, lbalid)
+	url := mk_url(path)
+	req, _ := http.NewRequest("POST", url, bytes.NewBuffer(jason))
+	req.Header.Add("Content-Type", FullHeader)
+	return toNic(do(req))
+}
+
+func GetBalancedNic(dcid, lbalid, balnicid string) Nic {
+	path := balnic_path(dcid, lbalid, balnicid)
+	url := mk_url(path) + `?depth=` + Depth
+	req, _ := http.NewRequest("GET", url, nil)
+	req.Header.Add("Content-Type", FullHeader)
+	return toNic(do(req))
+}
+
+func DeleteBalancedNic(dcid, lbalid, balnicid string) Resp {
+	path := balnic_path(dcid, lbalid, balnicid)
+	return is_delete(path)
+}
+
+func toLoadbalancer(resp Resp) Loadbalancer {
+	var server Loadbalancer
+	json.Unmarshal(resp.Body, &server)
+	server.Response = string(resp.Body)
+	server.Headers = &resp.Headers
+	server.StatusCode = resp.StatusCode
+	return server
+}
+
+func toLoadbalancers(resp Resp) Loadbalancers {
+	var col Loadbalancers
+	json.Unmarshal(resp.Body, &col)
+	col.Response = string(resp.Body)
+	col.Headers = &resp.Headers
+	col.StatusCode = resp.StatusCode
+	return col
+}

--- a/vendor/github.com/profitbricks/profitbricks-sdk-go/loadbalancer_test.go
+++ b/vendor/github.com/profitbricks/profitbricks-sdk-go/loadbalancer_test.go
@@ -1,0 +1,138 @@
+// loadbalancer_test.go
+package profitbricks
+
+import (
+	"fmt"
+	"testing"
+)
+
+var lbal_dcid string
+var lbalid string
+var lbal_srvid string
+var lbal_ipid string
+
+func TestCreateLoadbalancer(t *testing.T) {
+	setupTestEnv()
+	want := 202
+	lbal_dcid = mkdcid("GO SDK LB DC")
+	lbal_srvid = mksrvid(lbal_dcid)
+	var obj = IpBlock{
+		Properties: IpBlockProperties{
+			Size:     1,
+			Location: "us/las",
+		},
+	}
+	resp := ReserveIpBlock(obj)
+	waitTillProvisioned(resp.Headers.Get("Location"))
+	lbal_ipid = resp.Id
+	var request = Loadbalancer{
+		Properties: LoadbalancerProperties{
+			Name: "test",
+			Ip:   resp.Properties.Ips[0],
+			Dhcp: true,
+		},
+	}
+
+	resp1 := CreateLoadbalancer(lbal_dcid, request)
+	waitTillProvisioned(resp1.Headers.Get("Location"))
+	lbalid = resp1.Id
+	fmt.Println("Loadbalancer ID", lbalid)
+	if resp1.StatusCode != want {
+		t.Errorf(bad_status(want, resp1.StatusCode))
+	}
+
+}
+
+func TestListLoadbalancers(t *testing.T) {
+	want := 200
+	resp := ListLoadbalancers(lbal_dcid)
+
+	if resp.StatusCode != want {
+		t.Errorf(bad_status(want, resp.StatusCode))
+	}
+}
+
+func TestGetLoadbalancer(t *testing.T) {
+	want := 200
+	fmt.Println("TestGetLoadbalancer", lbalid)
+
+	resp := GetLoadbalancer(lbal_dcid, lbalid)
+
+	if resp.StatusCode != want {
+		t.Errorf(bad_status(want, resp.StatusCode))
+	}
+}
+
+func TestPatchLoadbalancer(t *testing.T) {
+	want := 202
+
+	obj := LoadbalancerProperties{Name: "Renamed Loadbalancer"}
+
+	resp := PatchLoadbalancer(lbal_dcid, lbalid, obj)
+	waitTillProvisioned(resp.Headers.Get("Location"))
+	if resp.StatusCode != want {
+		fmt.Println(string(resp.Response))
+		t.Errorf(bad_status(want, resp.StatusCode))
+	}
+}
+
+func TestAssociateNic(t *testing.T) {
+	want := 202
+
+	nicid = mknic(lbal_dcid, lbal_srvid)
+	fmt.Println("AssociateNic params ", lbal_dcid, lbalid, nicid)
+	resp := AssociateNic(lbal_dcid, lbalid, nicid)
+	waitTillProvisioned(resp.Headers.Get("Location"))
+	nicid = resp.Id
+	if resp.StatusCode != want {
+		t.Error(resp.Response)
+		t.Errorf(bad_status(want, resp.StatusCode))
+	}
+}
+
+func TestGetBalancedNics(t *testing.T) {
+	want := 200
+	resp := ListBalancedNics(lbal_dcid, lbalid)
+
+	if resp.StatusCode != want {
+		t.Errorf(bad_status(want, resp.StatusCode))
+	}
+}
+
+func TestGetBalancedNic(t *testing.T) {
+	want := 200
+	resp := GetBalancedNic(lbal_dcid, lbalid, nicid)
+
+	if resp.StatusCode != want {
+		t.Errorf(bad_status(want, resp.StatusCode))
+	}
+}
+
+func TestDeleteBalancedNic(t *testing.T) {
+	want := 202
+
+	resp := DeleteBalancedNic(lbal_dcid, lbalid, nicid)
+	waitTillProvisioned(resp.Headers.Get("Location"))
+
+	if resp.StatusCode != want {
+		t.Error(string(resp.Body))
+		t.Errorf(bad_status(want, resp.StatusCode))
+	}
+}
+
+func TestDeleteLoadbalancer(t *testing.T) {
+	want := 202
+	resp := DeleteLoadbalancer(lbal_dcid, lbalid)
+	waitTillProvisioned(resp.Headers.Get("Location"))
+	if resp.StatusCode != want {
+		t.Errorf(bad_status(want, resp.StatusCode))
+	}
+}
+
+func TestLoadBalancerCleanup(t *testing.T) {
+	resp := DeleteDatacenter(lbal_dcid)
+	waitTillProvisioned(resp.Headers.Get("Location"))
+	DeleteDatacenter(dcID)
+	ReleaseIpBlock(lbal_ipid)
+
+}

--- a/vendor/github.com/profitbricks/profitbricks-sdk-go/location.go
+++ b/vendor/github.com/profitbricks/profitbricks-sdk-go/location.go
@@ -1,0 +1,66 @@
+package profitbricks
+
+import (
+	"encoding/json"
+	"net/http"
+)
+
+type Location struct {
+	Id         string                    `json:"id,omitempty"`
+	Type_      string                    `json:"type,omitempty"`
+	Href       string                    `json:"href,omitempty"`
+	Metadata   DatacenterElementMetadata `json:"metadata,omitempty"`
+	Properties Properties                `json:"properties,omitempty"`
+	Response   string                    `json:"Response,omitempty"`
+	Headers    *http.Header              `json:"headers,omitempty"`
+	StatusCode int                       `json:"headers,omitempty"`
+}
+
+type Locations struct {
+	Id         string       `json:"id,omitempty"`
+	Type_      string       `json:"type,omitempty"`
+	Href       string       `json:"href,omitempty"`
+	Items      []Location   `json:"items,omitempty"`
+	Response   string       `json:"Response,omitempty"`
+	Headers    *http.Header `json:"headers,omitempty"`
+	StatusCode int          `json:"headers,omitempty"`
+}
+
+type Properties struct {
+	Name     string `json:"name,omitempty"`
+	Features []string `json:"features,omitempty"`
+}
+
+// ListLocations returns location collection data
+func ListLocations() Locations {
+	url := mk_url(location_col_path()) + `?depth=` + Depth
+	req, _ := http.NewRequest("GET", url, nil)
+	req.Header.Add("Content-Type", FullHeader)
+	return toLocations(do(req))
+}
+
+// GetLocation returns location data
+func GetLocation(locid string) Location {
+	url := mk_url(location_path(locid)) + `?depth=` + Depth
+	req, _ := http.NewRequest("GET", url, nil)
+	req.Header.Add("Content-Type", FullHeader)
+	return toLocation(do(req))
+}
+
+func toLocation(resp Resp) Location {
+	var obj Location
+	json.Unmarshal(resp.Body, &obj)
+	obj.Response = string(resp.Body)
+	obj.Headers = &resp.Headers
+	obj.StatusCode = resp.StatusCode
+	return obj
+}
+
+func toLocations(resp Resp) Locations {
+	var col Locations
+	json.Unmarshal(resp.Body, &col)
+	col.Response = string(resp.Body)
+	col.Headers = &resp.Headers
+	col.StatusCode = resp.StatusCode
+	return col
+}

--- a/vendor/github.com/profitbricks/profitbricks-sdk-go/location_test.go
+++ b/vendor/github.com/profitbricks/profitbricks-sdk-go/location_test.go
@@ -1,0 +1,28 @@
+package profitbricks
+
+import (
+	"testing"
+	"fmt"
+)
+
+var locid string
+
+func TestListLocations(t *testing.T) {
+	setupTestEnv()
+	want := 200
+	resp := ListLocations()
+	if resp.StatusCode != want {
+		t.Errorf(bad_status(want, resp.StatusCode))
+	}
+	locid = resp.Items[0].Id
+}
+
+func TestGetLocation(t *testing.T) {
+	//t.Parallel()
+	want := 200
+	resp := GetLocation("us/las")
+
+	if resp.StatusCode != want {
+		t.Errorf(bad_status(want, resp.StatusCode))
+	}
+}

--- a/vendor/github.com/profitbricks/profitbricks-sdk-go/nic.go
+++ b/vendor/github.com/profitbricks/profitbricks-sdk-go/nic.go
@@ -1,0 +1,111 @@
+package profitbricks
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+)
+
+type Nic struct {
+	Id         string                     `json:"id,omitempty"`
+	Type_      string                     `json:"type,omitempty"`
+	Href       string                     `json:"href,omitempty"`
+	Metadata   *DatacenterElementMetadata `json:"metadata,omitempty"`
+	Properties NicProperties              `json:"properties,omitempty"`
+	Entities   *NicEntities               `json:"entities,omitempty"`
+	Response   string                     `json:"Response,omitempty"`
+	Headers    *http.Header               `json:"headers,omitempty"`
+	StatusCode int                        `json:"headers,omitempty"`
+}
+
+type NicProperties struct {
+	Name           string   `json:"name,omitempty"`
+	Mac            string   `json:"mac,omitempty"`
+	Ips            []string `json:"ips,omitempty"`
+	Dhcp           bool     `json:"dhcp,omitempty"`
+	Lan            int      `json:"lan,omitempty"`
+	FirewallActive bool     `json:"firewallActive,omitempty"`
+	Nat            bool     `json:"nat,omitempty"`
+}
+
+type NicEntities struct {
+	Firewallrules *FirewallRules `json:"firewallrules,omitempty"`
+}
+
+type Nics struct {
+	Id         string       `json:"id,omitempty"`
+	Type_      string       `json:"type,omitempty"`
+	Href       string       `json:"href,omitempty"`
+	Items      []Nic        `json:"items,omitempty"`
+	Response   string       `json:"Response,omitempty"`
+	Headers    *http.Header `json:"headers,omitempty"`
+	StatusCode int          `json:"headers,omitempty"`
+}
+
+type NicCreateRequest struct {
+	NicProperties `json:"properties"`
+}
+
+// ListNics returns a Nics struct collection
+func ListNics(dcid, srvid string) Nics {
+	path := nic_col_path(dcid, srvid) + `?depth=` + Depth
+	url := mk_url(path) + `?depth=` + Depth
+	req, _ := http.NewRequest("GET", url, nil)
+	req.Header.Add("Content-Type", FullHeader)
+	return toNics(do(req))
+}
+
+// CreateNic creates a nic on a server
+// from a jason []byte and returns a Instance struct
+func CreateNic(dcid string, srvid string, request Nic) Nic {
+	obj, _ := json.Marshal(request)
+	path := nic_col_path(dcid, srvid)
+	url := mk_url(path) + `?depth=` + Depth
+	req, _ := http.NewRequest("POST", url, bytes.NewBuffer(obj))
+	req.Header.Add("Content-Type", FullHeader)
+	return toNic(do(req))
+}
+
+// GetNic pulls data for the nic where id = srvid returns a Instance struct
+func GetNic(dcid, srvid, nicid string) Nic {
+	path := nic_path(dcid, srvid, nicid)
+	url := mk_url(path) + `?depth=` + Depth
+	req, _ := http.NewRequest("GET", url, nil)
+	req.Header.Add("Content-Type", FullHeader)
+	return toNic(do(req))
+}
+
+// PatchNic partial update of nic properties passed in as jason []byte
+// Returns Instance struct
+func PatchNic(dcid string, srvid string, nicid string, obj NicProperties) Nic {
+	jason := []byte(MkJson(obj))
+	path := nic_path(dcid, srvid, nicid)
+	url := mk_url(path)
+	req, _ := http.NewRequest("PATCH", url, bytes.NewBuffer(jason))
+	req.Header.Add("Content-Type", PatchHeader)
+	return toNic(do(req))
+}
+
+// DeleteNic deletes the nic where id=nicid and returns a Resp struct
+func DeleteNic(dcid, srvid, nicid string) Resp {
+	path := nic_path(dcid, srvid, nicid)
+	return is_delete(path)
+}
+
+func toNic(resp Resp) Nic {
+	var obj Nic
+	json.Unmarshal(resp.Body, &obj)
+	obj.Response = string(resp.Body)
+	obj.Headers = &resp.Headers
+	obj.StatusCode = resp.StatusCode
+	return obj
+}
+
+func toNics(resp Resp) Nics {
+	var col Nics
+	json.Unmarshal(resp.Body, &col)
+	col.Response = string(resp.Body)
+	col.Headers = &resp.Headers
+	col.StatusCode = resp.StatusCode
+	return col
+}

--- a/vendor/github.com/profitbricks/profitbricks-sdk-go/nic_test.go
+++ b/vendor/github.com/profitbricks/profitbricks-sdk-go/nic_test.go
@@ -1,0 +1,72 @@
+package profitbricks
+
+import (
+	"testing"
+)
+
+var nic_dcid string
+var nic_srvid string
+var nicid string
+
+func TestCreateNic(t *testing.T) {
+	setupTestEnv()
+	nic_dcid = mkdcid("GO SDK NIC DC")
+	nic_srvid = mksrvid(nic_dcid)
+
+	want := 202
+	var request = Nic{
+		Properties: NicProperties{
+			Lan:  1,
+			Name: "Test NIC",
+			Nat:  false,
+		},
+	}
+
+	resp := CreateNic(nic_dcid, nic_srvid, request)
+	waitTillProvisioned(resp.Headers.Get("Location"))
+	nicid = resp.Id
+	if resp.StatusCode != want {
+		t.Error(resp.Response)
+		t.Errorf(bad_status(want, resp.StatusCode))
+	}
+}
+
+func TestListNics(t *testing.T) {
+	//t.Parallel()
+	want := 200
+	resp := ListNics(nic_dcid, nic_srvid)
+
+	if resp.StatusCode != want {
+		t.Errorf(bad_status(want, resp.StatusCode))
+	}
+}
+
+func TestGetNic(t *testing.T) {
+	want := 200
+	resp := GetNic(nic_dcid, nic_srvid, nicid)
+
+	if resp.StatusCode != want {
+		t.Errorf(bad_status(want, resp.StatusCode))
+	}
+}
+func TestPatchNic(t *testing.T) {
+	want := 202
+	obj := NicProperties{Name: "Renamed Nic", Lan: 1}
+
+	resp := PatchNic(nic_dcid, nic_srvid, nicid, obj)
+	if resp.StatusCode != want {
+		t.Errorf(bad_status(want, resp.StatusCode))
+	}
+}
+func TestDeleteNic(t *testing.T) {
+	want := 202
+	resp := DeleteNic(nic_dcid, nic_srvid, nicid)
+	if resp.StatusCode != want {
+		t.Errorf(bad_status(want, resp.StatusCode))
+	}
+}
+
+func TestNicCleanup(t *testing.T) {
+	DeleteServer(nic_dcid, nic_srvid)
+	DeleteDatacenter(nic_dcid)
+}

--- a/vendor/github.com/profitbricks/profitbricks-sdk-go/paths.go
+++ b/vendor/github.com/profitbricks/profitbricks-sdk-go/paths.go
@@ -1,0 +1,147 @@
+package profitbricks
+
+// slash returns "/<str>" great for making url paths
+func slash(str string) string {
+	return "/" + str
+}
+
+// dc_col_path	returns the string "/datacenters"
+func dc_col_path() string {
+	return slash("datacenters")
+}
+
+// dc_path returns the string "/datacenters/<dcid>"
+func dc_path(dcid string) string {
+	return dc_col_path() + slash(dcid)
+}
+
+// image_col_path returns the string" /images"
+func image_col_path() string {
+	return slash("images")
+}
+
+// image_path returns the string"/images/<imageid>"
+func image_path(imageid string) string {
+	return image_col_path() + slash(imageid)
+}
+
+// ipblock_col_path returns the string "/ipblocks"
+func ipblock_col_path() string {
+	return slash("ipblocks")
+}
+
+//  ipblock_path returns the string "/ipblocks/<ipblockid>"
+func ipblock_path(ipblockid string) string {
+	return ipblock_col_path() + slash(ipblockid)
+}
+
+// location_col_path returns the string  "/locations"
+func location_col_path() string {
+	return slash("locations")
+}
+
+// location_path returns the string   "/locations/<locid>"
+func location_path(locid string) string {
+	return location_col_path() + slash(locid)
+}
+
+// snapshot_col_path returns the string "/snapshots"
+func snapshot_col_path() string {
+	return slash("snapshots")
+}
+
+// lan_col_path returns the string "/datacenters/<dcid>/lans"
+func lan_col_path(dcid string) string {
+	return dc_path(dcid) + slash("lans")
+}
+
+// lan_path returns the string	"/datacenters/<dcid>/lans/<lanid>"
+func lan_path(dcid, lanid string) string {
+	return lan_col_path(dcid) + slash(lanid)
+}
+
+//  lbal_col_path returns the string "/loadbalancers"
+func lbal_col_path(dcid string) string {
+	return dc_path(dcid) + slash("loadbalancers")
+}
+
+// lbalpath returns the string "/loadbalancers/<lbalid>"
+func lbal_path(dcid, lbalid string) string {
+	return lbal_col_path(dcid) + slash(lbalid)
+}
+
+// server_col_path returns the string	"/datacenters/<dcid>/servers"
+func server_col_path(dcid string) string {
+	return dc_path(dcid) + slash("servers")
+}
+
+// server_path returns the string   "/datacenters/<dcid>/servers/<srvid>"
+func server_path(dcid, srvid string) string {
+	return server_col_path(dcid) + slash(srvid)
+}
+
+// server_cmd_path returns the string   "/datacenters/<dcid>/servers/<srvid>/<cmd>"
+func server_command_path(dcid, srvid, cmd string) string {
+	return server_path(dcid, srvid) + slash(cmd)
+}
+
+// volume_col_path returns the string "/volumes"
+func volume_col_path(dcid string) string {
+	return dc_path(dcid) + slash("volumes")
+}
+
+// volume_path returns the string "/volumes/<volid>"
+func volume_path(dcid, volid string) string {
+	return volume_col_path(dcid) + slash(volid)
+}
+
+//  balnic_col_path returns the string "/loadbalancers/<lbalid>/balancednics"
+func balnic_col_path(dcid, lbalid string) string {
+	return lbal_path(dcid, lbalid) + slash("balancednics")
+}
+
+//  balnic_path returns the string "/loadbalancers/<lbalid>/balancednics<balnicid>"
+func balnic_path(dcid, lbalid, balnicid string) string {
+	return balnic_col_path(dcid, lbalid) + slash(balnicid)
+}
+
+// server_cdrom_col_path returns the string   "/datacenters/<dcid>/servers/<srvid>/cdroms"
+func server_cdrom_col_path(dcid, srvid string) string {
+	return server_path(dcid, srvid) + slash("cdroms")
+}
+
+// server_cdrom_path returns the string   "/datacenters/<dcid>/servers/<srvid>/cdroms/<cdid>"
+func server_cdrom_path(dcid, srvid, cdid string) string {
+	return server_cdrom_col_path(dcid, srvid) + slash(cdid)
+}
+
+// server_volume_col_path returns the string   "/datacenters/<dcid>/servers/<srvid>/volumes"
+func server_volume_col_path(dcid, srvid string) string {
+	return server_path(dcid, srvid) + slash("volumes")
+}
+
+// server_volume_path returns the string   "/datacenters/<dcid>/servers/<srvid>/volumes/<volid>"
+func server_volume_path(dcid, srvid, volid string) string {
+	return server_volume_col_path(dcid, srvid) + slash(volid)
+}
+
+// nic_path returns the string   "/datacenters/<dcid>/servers/<srvid>/nics"
+func nic_col_path(dcid, srvid string) string {
+	return server_path(dcid, srvid) + slash("nics")
+}
+
+// nic_path returns the string   "/datacenters/<dcid>/servers/<srvid>/nics/<nicid>"
+func nic_path(dcid, srvid, nicid string) string {
+	return nic_col_path(dcid, srvid) + slash(nicid)
+}
+
+// fwrule_col_path returns the string   "/datacenters/<dcid>/servers/<srvid>/nics/<nicid>/firewallrules"
+func fwrule_col_path(dcid, srvid, nicid string) string {
+	return nic_path(dcid, srvid, nicid) + slash("firewallrules")
+}
+
+// fwrule_path returns the string
+//  "/datacenters/<dcid>/servers/<srvid>/nics/<nicid>/firewallrules/<fwruleid>"
+func fwrule_path(dcid, srvid, nicid, fwruleid string) string {
+	return fwrule_col_path(dcid, srvid, nicid) + slash(fwruleid)
+}

--- a/vendor/github.com/profitbricks/profitbricks-sdk-go/req.go
+++ b/vendor/github.com/profitbricks/profitbricks-sdk-go/req.go
@@ -1,0 +1,86 @@
+package profitbricks
+
+import (
+	"bytes"
+	"encoding/json"
+	"io/ioutil"
+	"net/http"
+	"strings"
+)
+
+//FullHeader is the standard header to include with all http requests except is_patch and is_command
+const FullHeader = "application/json"
+
+var AgentHeader = "profitbricks-sdk-go/3.0.1"
+
+//PatchHeader is used with is_patch .
+const PatchHeader = "application/json"
+
+//CommandHeader is used with is_command
+const CommandHeader = "application/x-www-form-urlencoded"
+
+var Depth = "5"
+
+// SetDepth is used to set Depth
+func SetDepth(newdepth string) string {
+	Depth = newdepth
+	return Depth
+}
+
+// mk_url  either:
+// returns the path (if it`s a full url)
+//			 or
+//	returns	Endpoint+ path .
+func mk_url(path string) string {
+	if strings.HasPrefix(path, "http") {
+		//REMOVE AFTER TESTING
+		//FIXME @jasmin Is this still relevant?
+		path := strings.Replace(path, "https://api.profitbricks.com/cloudapi/v3", Endpoint, 1)
+		// END REMOVE
+		return path
+	}
+	if strings.HasPrefix(path, "<base>") {
+		//REMOVE AFTER TESTING
+		path := strings.Replace(path, "<base>", Endpoint, 1)
+		return path
+	}
+	url := Endpoint + path
+	return url
+}
+
+func do(req *http.Request) Resp {
+	client := &http.Client{}
+	req.SetBasicAuth(Username, Passwd)
+	req.Header.Add("User-Agent", AgentHeader)
+	resp, err := client.Do(req)
+	if err != nil {
+		panic(err)
+	}
+	defer resp.Body.Close()
+	resp_body, _ := ioutil.ReadAll(resp.Body)
+	var R Resp
+	R.Req = resp.Request
+	R.Body = resp_body
+	R.Headers = resp.Header
+	R.StatusCode = resp.StatusCode
+	return R
+}
+
+// is_delete performs an http.NewRequest DELETE  and returns a Resp struct
+func is_delete(path string) Resp {
+	url := mk_url(path)
+	req, _ := http.NewRequest("DELETE", url, nil)
+	req.Header.Add("Content-Type", FullHeader)
+	req.Header.Add("User-Agent", AgentHeader)
+	return do(req)
+}
+
+// is_command performs an http.NewRequest POST and returns a Resp struct
+func is_command(path string, jason string) Resp {
+	url := mk_url(path)
+	body := json.RawMessage(jason)
+	req, _ := http.NewRequest("POST", url, bytes.NewBuffer(body))
+	req.Header.Add("Content-Type", CommandHeader)
+	req.Header.Add("User-Agent", AgentHeader)
+	return do(req)
+}

--- a/vendor/github.com/profitbricks/profitbricks-sdk-go/request.go
+++ b/vendor/github.com/profitbricks/profitbricks-sdk-go/request.go
@@ -1,0 +1,43 @@
+package profitbricks
+
+import (
+	"encoding/json"
+	"net/http"
+)
+
+type RequestStatus struct {
+	Id         string                `json:"id,omitempty"`
+	Type_      string                `json:"type,omitempty"`
+	Href       string                `json:"href,omitempty"`
+	Metadata   RequestStatusMetadata `json:"metadata,omitempty"`
+	Response   string                `json:"Response,omitempty"`
+	Headers    *http.Header          `json:"headers,omitempty"`
+	StatusCode int                   `json:"headers,omitempty"`
+}
+type RequestStatusMetadata struct {
+	Status  string          `json:"status,omitempty"`
+	Message string          `json:"message,omitempty"`
+	Etag    string          `json:"etag,omitempty"`
+	Targets []RequestTarget `json:"targets,omitempty"`
+}
+
+type RequestTarget struct {
+	Target ResourceReference `json:"target,omitempty"`
+	Status string            `json:"status,omitempty"`
+}
+
+func GetRequestStatus(path string) RequestStatus {
+	url := mk_url(path) + `?depth=` + Depth
+	req, _ := http.NewRequest("GET", url, nil)
+	req.Header.Add("Content-Type", FullHeader)
+	return toRequestStatus(do(req))
+}
+
+func toRequestStatus(resp Resp) RequestStatus {
+	var server RequestStatus
+	json.Unmarshal(resp.Body, &server)
+	server.Response = string(resp.Body)
+	server.Headers = &resp.Headers
+	server.StatusCode = resp.StatusCode
+	return server
+}

--- a/vendor/github.com/profitbricks/profitbricks-sdk-go/request_test.go
+++ b/vendor/github.com/profitbricks/profitbricks-sdk-go/request_test.go
@@ -1,0 +1,15 @@
+package profitbricks
+
+import (
+	"testing"
+)
+
+func TestGetRequestStatus(t *testing.T) {
+	setupTestEnv()
+	want := 200
+	resp := GetRequestStatus("https://api.profitbricks.com/rest/v2/requests/2b31cc27-a604-4751-afc4-497b481e353d/status")
+	if resp.StatusCode != want {
+		t.Errorf(bad_status(want, resp.StatusCode))
+	}
+
+}

--- a/vendor/github.com/profitbricks/profitbricks-sdk-go/resp.go
+++ b/vendor/github.com/profitbricks/profitbricks-sdk-go/resp.go
@@ -1,0 +1,32 @@
+package profitbricks
+
+import "net/http"
+import "fmt"
+import (
+	"encoding/json"
+)
+
+func MkJson(i interface{}) string {
+	jason, err := json.MarshalIndent(&i, "", "    ")
+	if err != nil {
+		panic(err)
+	}
+	//	fmt.Println(string(jason))
+	return string(jason)
+}
+
+// Resp is the struct returned by all Rest request functions
+type Resp struct {
+	Req        *http.Request
+	StatusCode int
+	Headers    http.Header
+	Body       []byte
+}
+
+// PrintHeaders prints the http headers as k,v pairs
+func (r *Resp) PrintHeaders() {
+	for key, value := range r.Headers {
+		fmt.Println(key, " : ", value[0])
+	}
+
+}

--- a/vendor/github.com/profitbricks/profitbricks-sdk-go/server.go
+++ b/vendor/github.com/profitbricks/profitbricks-sdk-go/server.go
@@ -1,0 +1,206 @@
+package profitbricks
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+)
+
+type Server struct {
+	Id         string                     `json:"id,omitempty"`
+	Type_      string                     `json:"type,omitempty"`
+	Href       string                     `json:"href,omitempty"`
+	Metadata   *DatacenterElementMetadata `json:"metadata,omitempty"`
+	Properties ServerProperties           `json:"properties,omitempty"`
+	Entities   *ServerEntities            `json:"entities,omitempty"`
+	Response   string                     `json:"Response,omitempty"`
+	Headers    *http.Header               `json:"headers,omitempty"`
+	StatusCode int                        `json:"headers,omitempty"`
+}
+
+type ServerProperties struct {
+	Name             string             `json:"name,omitempty"`
+	Cores            int                `json:"cores,omitempty"`
+	Ram              int                `json:"ram,omitempty"`
+	AvailabilityZone string             `json:"availabilityZone,omitempty"`
+	VmState          string             `json:"vmState,omitempty"`
+	BootCdrom        *ResourceReference `json:"bootCdrom,omitempty"`
+	BootVolume       *ResourceReference `json:"bootVolume,omitempty"`
+	CpuFamily        string             `json:"cpuFamily,omitempty"`
+}
+
+type ServerEntities struct {
+	Cdroms  *Cdroms  `json:"cdroms,omitempty"`
+	Volumes *Volumes `json:"volumes,omitempty"`
+	Nics    *Nics    `json:"nics,omitempty"`
+}
+
+type Servers struct {
+	Id         string       `json:"id,omitempty"`
+	Type_      string       `json:"type,omitempty"`
+	Href       string       `json:"href,omitempty"`
+	Items      []Server     `json:"items,omitempty"`
+	Response   string       `json:"Response,omitempty"`
+	Headers    *http.Header `json:"headers,omitempty"`
+	StatusCode int          `json:"headers,omitempty"`
+}
+
+type ResourceReference struct {
+	Id    string `json:"id,omitempty"`
+	Type_ string `json:"type,omitempty"`
+	Href  string `json:"href,omitempty"`
+}
+
+type CreateServerRequest struct {
+	ServerProperties `json:"properties"`
+}
+
+// ListServers returns a server struct collection
+func ListServers(dcid string) Servers {
+	path := server_col_path(dcid)
+	url := mk_url(path) + `?depth=` + Depth
+	req, _ := http.NewRequest("GET", url, nil)
+	req.Header.Add("Content-Type", FullHeader)
+	resp := do(req)
+	return toServers(resp)
+}
+
+// CreateServer creates a server from a jason []byte and returns a Instance struct
+func CreateServer(dcid string, server Server) Server {
+	obj, _ := json.Marshal(server)
+	path := server_col_path(dcid)
+	url := mk_url(path) + `?depth=` + Depth
+	req, _ := http.NewRequest("POST", url, bytes.NewBuffer(obj))
+	req.Header.Add("Content-Type", FullHeader)
+	return toServer(do(req))
+}
+
+// GetServer pulls data for the server where id = srvid returns a Instance struct
+func GetServer(dcid, srvid string) Server {
+	path := server_path(dcid, srvid)
+	url := mk_url(path) + `?depth=` + Depth
+	req, _ := http.NewRequest("GET", url, nil)
+	req.Header.Add("Content-Type", FullHeader)
+	return toServer(do(req))
+}
+
+// PatchServer partial update of server properties passed in as jason []byte
+// Returns Instance struct
+func PatchServer(dcid string, srvid string, props ServerProperties) Server {
+	jason, _ := json.Marshal(props)
+	path := server_path(dcid, srvid)
+	url := mk_url(path) + `?depth=` + Depth
+	req, _ := http.NewRequest("PATCH", url, bytes.NewBuffer(jason))
+	req.Header.Add("Content-Type", PatchHeader)
+	return toServer(do(req))
+}
+
+// DeleteServer deletes the server where id=srvid and returns Resp struct
+func DeleteServer(dcid, srvid string) Resp {
+	path := server_path(dcid, srvid)
+	return is_delete(path)
+}
+
+func ListAttachedCdroms(dcid, srvid string) Images {
+	path := server_cdrom_col_path(dcid, srvid)
+	url := mk_url(path) + `?depth=` + Depth
+	req, _ := http.NewRequest("GET", url, nil)
+	req.Header.Add("Content-Type", FullHeader)
+	return toImages(do(req))
+}
+
+func AttachCdrom(dcid string, srvid string, cdid string) Image {
+	jason := []byte(`{"id":"` + cdid + `"}`)
+	path := server_cdrom_col_path(dcid, srvid)
+	url := mk_url(path) + `?depth=` + Depth
+	req, _ := http.NewRequest("POST", url, bytes.NewBuffer(jason))
+	req.Header.Add("Content-Type", FullHeader)
+	return toImage(do(req))
+}
+
+func GetAttachedCdrom(dcid, srvid, cdid string) Volume {
+	path := server_cdrom_path(dcid, srvid, cdid)
+	url := mk_url(path) + `?depth=` + Depth
+	req, _ := http.NewRequest("GET", url, nil)
+	req.Header.Add("Content-Type", FullHeader)
+	return toVolume(do(req))
+}
+
+func DetachCdrom(dcid, srvid, cdid string) Resp {
+	path := server_cdrom_path(dcid, srvid, cdid)
+	return is_delete(path)
+}
+
+func ListAttachedVolumes(dcid, srvid string) Volumes {
+	path := server_volume_col_path(dcid, srvid)
+	url := mk_url(path) + `?depth=` + Depth
+	req, _ := http.NewRequest("GET", url, nil)
+	req.Header.Add("Content-Type", FullHeader)
+	resp := do(req)
+	return toVolumes(resp)
+}
+
+func AttachVolume(dcid string, srvid string, volid string) Volume {
+	jason := []byte(`{"id":"` + volid + `"}`)
+	path := server_volume_col_path(dcid, srvid)
+	url := mk_url(path) + `?depth=` + Depth
+	req, _ := http.NewRequest("POST", url, bytes.NewBuffer(jason))
+	req.Header.Add("Content-Type", FullHeader)
+	return toVolume(do(req))
+}
+
+func GetAttachedVolume(dcid, srvid, volid string) Volume {
+	path := server_volume_path(dcid, srvid, volid)
+	url := mk_url(path) + `?depth=` + Depth
+	req, _ := http.NewRequest("GET", url, nil)
+	req.Header.Add("Content-Type", FullHeader)
+	resp := do(req)
+	return toVolume(resp)
+}
+
+func DetachVolume(dcid, srvid, volid string) Resp {
+	path := server_volume_path(dcid, srvid, volid)
+	return is_delete(path)
+}
+
+// StartServer starts a server
+func StartServer(dcid, srvid string) Resp {
+	return server_command(dcid, srvid, "start")
+}
+
+// StopServer stops a server
+func StopServer(dcid, srvid string) Resp {
+	return server_command(dcid, srvid, "stop")
+}
+
+// RebootServer reboots a server
+func RebootServer(dcid, srvid string) Resp {
+	return server_command(dcid, srvid, "reboot")
+}
+
+// server_command is a generic function for running server commands
+func server_command(dcid, srvid, cmd string) Resp {
+	jason := `
+		{}
+		`
+	path := server_command_path(dcid, srvid, cmd)
+	return is_command(path, jason)
+}
+
+func toServer(resp Resp) Server {
+	var server Server
+	json.Unmarshal(resp.Body, &server)
+	server.Response = string(resp.Body)
+	server.Headers = &resp.Headers
+	server.StatusCode = resp.StatusCode
+	return server
+}
+
+func toServers(resp Resp) Servers {
+	var col Servers
+	json.Unmarshal(resp.Body, &col)
+	col.Response = string(resp.Body)
+	col.Headers = &resp.Headers
+	col.StatusCode = resp.StatusCode
+	return col
+}

--- a/vendor/github.com/profitbricks/profitbricks-sdk-go/server_test.go
+++ b/vendor/github.com/profitbricks/profitbricks-sdk-go/server_test.go
@@ -1,0 +1,366 @@
+// server_test.go
+package profitbricks
+
+import (
+	"fmt"
+	"sync"
+	"testing"
+)
+
+var (
+	once_dc sync.Once
+	once_srv sync.Once
+	once_volume sync.Once
+	srv_dc_id string
+	srv_srvid string
+	srv_vol string
+	imageId string
+)
+
+func setupDataCenter() {
+	setupTestEnv()
+	srv_dc_id = mkdcid("GO SDK SERVER DC 02")
+	fmt.Println("Datacenter id: ", srv_dc_id)
+	if len(srv_dc_id) == 0 {
+		fmt.Errorf("DataCenter not created %s", srv_dc_id)
+	}
+}
+
+func setupServer() {
+	srv_srvid = setupCreateServer(srv_dc_id)
+	fmt.Println("Server id: ", srv_srvid)
+	if len(srv_srvid) == 0 {
+		fmt.Errorf("Server not created %s", srv_srvid)
+	}
+}
+
+func setupVolume() {
+
+	vol := Volume{
+		Properties: VolumeProperties{
+			Type:          "HDD",
+			Image:         image,
+			Size:          5,
+			ImagePassword: "test1234",
+		},
+	}
+	resp := CreateVolume(srv_dc_id, vol)
+	srv_vol = resp.Id
+
+	waitTillProvisioned(resp.Headers.Get("Location"))
+	if len(srv_vol) == 0 {
+		fmt.Errorf("Volume not created %s", 1)
+	}
+
+}
+
+func setupCreateServer(srv_dc_id string) string {
+
+	var req = Server{
+		Properties: ServerProperties{
+			Name:  "test",
+			Ram:   1024,
+			Cores: 2,
+		},
+	}
+	fmt.Println("Creating server....")
+	srv := CreateServer(srv_dc_id, req)
+	// wait for server to be running
+	waitTillProvisioned(srv.Headers.Get("Location"))
+	srvid := srv.Id
+	return srvid
+}
+
+func TestCreateServer(t *testing.T) {
+	once_dc.Do(setupDataCenter)
+
+	want := 202
+
+	var req = Server{
+		Properties: ServerProperties{
+			Name:  "go01",
+			Ram:   1024,
+			Cores: 2,
+		},
+	}
+	t.Logf("Creating server in DC: %s", srv_dc_id)
+	srv := CreateServer(srv_dc_id, req)
+	waitTillProvisioned(srv.Headers.Get("Location"))
+	srv_srvid = srv.Id
+	if srv.StatusCode != want {
+		t.Errorf(bad_status(want, srv.StatusCode))
+	}
+}
+
+func TestGetServer(t *testing.T) {
+	want := 200
+	resp := GetServer(srv_dc_id, srv_srvid)
+
+	if resp.StatusCode != want {
+		t.Errorf(bad_status(want, resp.StatusCode))
+	}
+}
+
+func TestListServers(t *testing.T) {
+	if srv_dc_id == "" {
+		once_dc.Do(setupDataCenter)
+		once_srv.Do(setupServer)
+	}
+
+	want := 200
+
+	resp := ListServers(srv_dc_id)
+
+	if resp.StatusCode != want {
+		t.Errorf(bad_status(want, resp.StatusCode))
+	}
+
+}
+
+func TestPatchServer(t *testing.T) {
+	once_dc.Do(setupDataCenter)
+	once_srv.Do(setupServer)
+
+	once_dc.Do(setupDataCenter)
+	once_srv.Do(setupServer)
+
+	want := 202
+	req := ServerProperties{
+		Name:  "go01renamed",
+		Cores: 1,
+	}
+	fmt.Println("SERVER ID : ", srv_srvid)
+	resp := PatchServer(srv_dc_id, srv_srvid, req)
+	if resp.StatusCode != want {
+		t.Error("resp: ", resp.Response)
+		t.Errorf(bad_status(want, resp.StatusCode))
+	}
+}
+
+func TestStopServer(t *testing.T) {
+	once_dc.Do(setupDataCenter)
+	once_srv.Do(setupServer)
+
+	want := 202
+	resp := StopServer(srv_dc_id, srv_srvid)
+	if resp.StatusCode != want {
+		t.Errorf(bad_status(want, resp.StatusCode))
+	}
+
+}
+
+func TestStartServer(t *testing.T) {
+	once_dc.Do(setupDataCenter)
+	once_srv.Do(setupServer)
+
+	want := 202
+	resp := StartServer(srv_dc_id, srv_srvid)
+	if resp.StatusCode != want {
+		t.Errorf(bad_status(want, resp.StatusCode))
+	}
+
+}
+
+func TestRebootServer(t *testing.T) {
+	once_dc.Do(setupDataCenter)
+	once_srv.Do(setupServer)
+
+	want := 202
+	resp := RebootServer(srv_dc_id, srv_srvid)
+	if resp.StatusCode != want {
+		t.Errorf(bad_status(want, resp.StatusCode))
+	}
+
+}
+
+func TestAttachImage(t *testing.T) {
+	once_dc.Do(setupDataCenter)
+	once_srv.Do(setupServer)
+	once_volume.Do(setupVolume)
+
+	want := 202
+
+	resp := AttachVolume(srv_dc_id, srv_srvid, srv_vol)
+	waitTillProvisioned(resp.Headers.Get("Location"))
+
+	if resp.StatusCode != want {
+		t.Error(string(resp.Response))
+		t.Errorf(bad_status(want, resp.StatusCode))
+	}
+}
+
+func TestListAttachedVolumes(t *testing.T) {
+	once_dc.Do(setupDataCenter)
+	once_srv.Do(setupServer)
+
+	want := 200
+
+	resp := ListAttachedVolumes(srv_dc_id, srv_srvid)
+
+	if resp.StatusCode != want {
+		t.Error(string(resp.Response))
+		t.Errorf(bad_status(want, resp.StatusCode))
+	}
+}
+
+func TestGetAttachedVolume(t *testing.T) {
+	once_dc.Do(setupDataCenter)
+	once_srv.Do(setupServer)
+
+	want := 200
+
+	resp := GetAttachedVolume(srv_dc_id, srv_srvid, srv_vol)
+	fmt.Println(resp)
+
+	if resp.StatusCode != want {
+		t.Error(string(resp.Response))
+		t.Errorf(bad_status(want, resp.StatusCode))
+	}
+}
+
+func TestDetachVolume(t *testing.T) {
+	once_dc.Do(setupDataCenter)
+	once_srv.Do(setupServer)
+	once_volume.Do(setupVolume)
+
+	want := 202
+	fmt.Println(srv_dc_id, srv_srvid, srv_vol)
+	resp := DetachVolume(srv_dc_id, srv_srvid, srv_vol)
+	if resp.StatusCode != want {
+		t.Error(string(resp.Body))
+		t.Errorf(bad_status(want, resp.StatusCode))
+	}
+}
+
+func TestAttachCdrom(t *testing.T) {
+	want := 202
+	once_dc.Do(setupDataCenter)
+	once_srv.Do(setupServer)
+
+	images := ListImages()
+	for _, image := range images.Items {
+		if image.Properties.ImageType == "CDROM" && image.Properties.Location == "us/las" {
+			imageId = image.Id
+			break
+		}
+	}
+
+	resp := AttachCdrom(srv_dc_id, srv_srvid, imageId)
+
+	waitTillProvisioned(resp.Headers.Get("Location"))
+
+	if resp.StatusCode != want {
+		t.Error(string(resp.Response))
+		t.Errorf(bad_status(want, resp.StatusCode))
+	}
+}
+
+func TestListAttachedCdroms(t *testing.T) {
+	want := 200
+
+	once_dc.Do(setupDataCenter)
+	once_srv.Do(setupServer)
+
+	resp := ListAttachedCdroms(srv_dc_id, srv_srvid)
+	if resp.StatusCode != want {
+		t.Error(string(resp.Response))
+		t.Errorf(bad_status(want, resp.StatusCode))
+	}
+}
+
+func TestGetAttachedCdrom(t *testing.T) {
+	want := 200
+
+	once_dc.Do(setupDataCenter)
+	once_srv.Do(setupServer)
+
+	resp := GetAttachedCdrom(srv_dc_id, srv_srvid, imageId)
+	if resp.StatusCode != want {
+		t.Error(string(resp.Response))
+		t.Errorf(bad_status(want, resp.StatusCode))
+	}
+}
+
+func TestDetachCdrom(t *testing.T) {
+	want := 202
+	once_dc.Do(setupDataCenter)
+	once_srv.Do(setupServer)
+
+	resp := DetachCdrom(srv_dc_id, srv_srvid, imageId)
+
+	if resp.StatusCode != want {
+		t.Errorf(bad_status(want, resp.StatusCode))
+	}
+}
+
+func TestDeleteServer(t *testing.T) {
+	once_dc.Do(setupDataCenter)
+	once_dc.Do(setupServer)
+
+	want := 202
+
+	resp := DeleteServer(srv_dc_id, srv_srvid)
+
+	if resp.StatusCode != want {
+		t.Error(string(resp.Body))
+		t.Errorf(bad_status(want, resp.StatusCode))
+	}
+
+	fmt.Println("Removed everything")
+}
+
+func TestCreateCompositeServer(t *testing.T) {
+	once_dc.Do(setupDataCenter)
+
+	want := 202
+
+	var req = Server{
+		Properties: ServerProperties{
+			Name:  "server1",
+			Ram:   2048,
+			Cores: 1,
+		},
+		Entities: &ServerEntities{
+			Volumes: &Volumes{
+				Items: []Volume{
+					{
+						Properties: VolumeProperties{
+							Type:          "HDD",
+							Size:          5,
+							Name:          "volume1",
+							Image:         image,
+							ImagePassword: "test1234",
+						},
+					},
+				},
+			},
+			Nics: &Nics{
+				Items: []Nic{
+					{
+						Properties: NicProperties{
+							Name: "nic",
+							Lan:  1,
+						},
+					},
+				},
+			},
+		},
+	}
+
+	t.Logf("Creating server in DC: %s", srv_dc_id)
+	srv := CreateServer(srv_dc_id, req)
+
+	if srv.StatusCode != want {
+		fmt.Println(srv.Response)
+		t.Errorf(bad_status(want, srv.StatusCode))
+	}
+	waitTillProvisioned(srv.Headers.Get("Location"))
+
+	resp := DeleteDatacenter(srv_dc_id)
+
+	if resp.StatusCode != want {
+		fmt.Println(srv.Response)
+		t.Errorf(bad_status(want, resp.StatusCode))
+
+	}
+}

--- a/vendor/github.com/profitbricks/profitbricks-sdk-go/snapshot.go
+++ b/vendor/github.com/profitbricks/profitbricks-sdk-go/snapshot.go
@@ -1,0 +1,96 @@
+package profitbricks
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+)
+
+type Snapshot struct {
+	Id         string                    `json:"id,omitempty"`
+	Type_      string                    `json:"type,omitempty"`
+	Href       string                    `json:"href,omitempty"`
+	Metadata   DatacenterElementMetadata `json:"metadata,omitempty"`
+	Properties SnapshotProperties        `json:"properties,omitempty"`
+	Response   string                    `json:"Response,omitempty"`
+	Headers    *http.Header              `json:"headers,omitempty"`
+	StatusCode int                       `json:"headers,omitempty"`
+}
+
+type SnapshotProperties struct {
+	Name                string `json:"name,omitempty"`
+	Description         string `json:"description,omitempty"`
+	Location            string `json:"location,omitempty"`
+	Size                int    `json:"size,omitempty"`
+	CpuHotPlug          bool   `json:"cpuHotPlug,omitempty"`
+	CpuHotUnplug        bool   `json:"cpuHotUnplug,omitempty"`
+	RamHotPlug          bool   `json:"ramHotPlug,omitempty"`
+	RamHotUnplug        bool   `json:"ramHotUnplug,omitempty"`
+	NicHotPlug          bool   `json:"nicHotPlug,omitempty"`
+	NicHotUnplug        bool   `json:"nicHotUnplug,omitempty"`
+	DiscVirtioHotPlug   bool   `json:"discVirtioHotPlug,omitempty"`
+	DiscVirtioHotUnplug bool   `json:"discVirtioHotUnplug,omitempty"`
+	DiscScsiHotPlug     bool   `json:"discScsiHotPlug,omitempty"`
+	DiscScsiHotUnplug   bool   `json:"discScsiHotUnplug,omitempty"`
+	LicenceType         string `json:"licenceType,omitempty"`
+}
+
+type Snapshots struct {
+	Id         string       `json:"id,omitempty"`
+	Type_      string       `json:"type,omitempty"`
+	Href       string       `json:"href,omitempty"`
+	Items      []Snapshot   `json:"items,omitempty"`
+	Response   string       `json:"Response,omitempty"`
+	Headers    *http.Header `json:"headers,omitempty"`
+	StatusCode int          `json:"headers,omitempty"`
+}
+
+func ListSnapshots() Snapshots {
+	path := snapshot_col_path()
+	url := mk_url(path) + `?depth=` + Depth
+	req, _ := http.NewRequest("GET", url, nil)
+	req.Header.Add("Content-Type", FullHeader)
+	return toSnapshots(do(req))
+}
+
+func GetSnapshot(snapshotId string) Snapshot {
+	path := snapshot_col_path() + slash(snapshotId)
+	url := mk_url(path) + `?depth=` + Depth
+	req, _ := http.NewRequest("GET", url, nil)
+	req.Header.Add("Content-Type", FullHeader)
+	return toSnapshot(do(req))
+}
+
+func DeleteSnapshot(snapshotId string) Resp {
+	path := snapshot_col_path() + slash(snapshotId)
+	url := mk_url(path)
+	req, _ := http.NewRequest("DELETE", url, nil)
+	req.Header.Add("Content-Type", FullHeader)
+	return do(req)
+}
+
+func UpdateSnapshot(snapshotId string, request SnapshotProperties) Snapshot {
+	path := snapshot_col_path() + slash(snapshotId)
+	obj, _ := json.Marshal(request)
+	url := mk_url(path)
+	req, _ := http.NewRequest("PATCH", url, bytes.NewBuffer(obj))
+	req.Header.Add("Content-Type", PatchHeader)
+	return toSnapshot(do(req))
+}
+
+func toSnapshot(resp Resp) Snapshot {
+	var lan Snapshot
+	json.Unmarshal(resp.Body, &lan)
+	lan.Response = string(resp.Body)
+	lan.Headers = &resp.Headers
+	lan.StatusCode = resp.StatusCode
+	return lan
+}
+func toSnapshots(resp Resp) Snapshots {
+	var col Snapshots
+	json.Unmarshal(resp.Body, &col)
+	col.Response = string(resp.Body)
+	col.Headers = &resp.Headers
+	col.StatusCode = resp.StatusCode
+	return col
+}

--- a/vendor/github.com/profitbricks/profitbricks-sdk-go/snapshot_test.go
+++ b/vendor/github.com/profitbricks/profitbricks-sdk-go/snapshot_test.go
@@ -1,0 +1,97 @@
+package profitbricks
+
+import (
+	"fmt"
+	"testing"
+)
+
+var snapshotId string
+
+func createVolume() {
+	setupTestEnv()
+	want := 202
+	var request = Volume{
+		Properties: VolumeProperties{
+			Size:          5,
+			Name:          "Volume Test",
+			Image:         image,
+			Type:          "HDD",
+			ImagePassword: "test1234",
+		},
+	}
+
+	dcID = mkdcid("GO SDK snapshot DC")
+	resp := CreateVolume(dcID, request)
+
+	waitTillProvisioned(resp.Headers.Get("Location"))
+	volumeId = resp.Id
+
+	if resp.StatusCode != want {
+		fmt.Println(string(resp.Response))
+	}
+}
+
+func createSnapshot() {
+	resp := CreateSnapshot(dcID, volumeId, "testSnapshot")
+	waitTillProvisioned(resp.Headers.Get("Location"))
+	snapshotId = resp.Id
+
+}
+
+func TestGetSnapshot(t *testing.T) {
+	createVolume()
+	createSnapshot()
+
+	want := 200
+
+	resp := GetSnapshot(snapshotId)
+
+	if resp.StatusCode != want {
+		fmt.Println(string(resp.Response))
+		t.Errorf(bad_status(want, resp.StatusCode))
+	}
+}
+
+func TestListSnapshot(t *testing.T) {
+	want := 200
+
+	resp := ListSnapshots()
+
+	if resp.StatusCode != want {
+		fmt.Println(string(resp.Response))
+		t.Errorf(bad_status(want, resp.StatusCode))
+	}
+}
+
+func TestUpdateSnapshot(t *testing.T) {
+	want := 202
+	newValue := "whatever"
+	resp := UpdateSnapshot(snapshotId, SnapshotProperties{Name: newValue})
+
+	if resp.StatusCode != want {
+		fmt.Println(string(resp.Response))
+		t.Errorf(bad_status(want, resp.StatusCode))
+	}
+
+	if newValue != resp.Properties.Name {
+		t.Errorf("Snapshot wasn't updated.")
+	}
+}
+
+func TestDeleteSnapshot(t *testing.T) {
+	want := 202
+
+	resp := DeleteSnapshot(snapshotId)
+
+	if resp.StatusCode != want {
+		fmt.Println(string(resp.Body))
+		t.Errorf(bad_status(want, resp.StatusCode))
+	}
+
+	resp = DeleteDatacenter(dcID)
+
+	if resp.StatusCode != want {
+		fmt.Println(string(resp.Body))
+		t.Errorf(bad_status(want, resp.StatusCode))
+	}
+}

--- a/vendor/github.com/profitbricks/profitbricks-sdk-go/test_helpers.go
+++ b/vendor/github.com/profitbricks/profitbricks-sdk-go/test_helpers.go
@@ -1,0 +1,105 @@
+package profitbricks
+
+import (
+	"fmt"
+	"time"
+	"strings"
+	"os"
+)
+
+func mkdcid(name string) string {
+	request := Datacenter{
+		Properties: DatacenterProperties{
+			Name:        name,
+			Description: "description",
+			Location:    "us/las",
+		},
+	}
+	dc := CreateDatacenter(request)
+	fmt.Println("===========================")
+	fmt.Println("Created a DC " + name)
+	fmt.Println("Created a DC id " + dc.Id)
+	fmt.Println(dc.StatusCode)
+	fmt.Println("===========================")
+	return dc.Id
+}
+
+func mksrvid(srv_dcid string) string {
+	var req = Server{
+		Properties: ServerProperties{
+			Name:  "GO SDK test",
+			Ram:   1024,
+			Cores: 2,
+		},
+	}
+	srv := CreateServer(srv_dcid, req)
+	fmt.Println("===========================")
+	fmt.Println("Created a server " + srv.Id)
+	fmt.Println(srv.StatusCode)
+	fmt.Println("===========================")
+
+	waitTillProvisioned(srv.Headers.Get("Location"))
+	return srv.Id
+}
+
+func mknic(lbal_dcid, serverid string) string {
+	var request = Nic{
+		Properties: NicProperties{
+			Name: "GO SDK Original Nic",
+			Lan:  1,
+		},
+	}
+
+	resp := CreateNic(lbal_dcid, serverid, request)
+	fmt.Println("===========================")
+	fmt.Println("created a nic at server " + serverid)
+
+	fmt.Println("created a nic with id " + resp.Id)
+	fmt.Println(resp.StatusCode)
+	fmt.Println("===========================")
+	waitTillProvisioned(resp.Headers.Get("Location"))
+	return resp.Id
+}
+
+func waitTillProvisioned(path string) {
+	waitCount := 120
+	fmt.Println(path)
+	for i := 0; i < waitCount; i++ {
+		request := GetRequestStatus(path)
+		if request.Metadata.Status == "DONE" {
+			break
+		}
+		time.Sleep(1 * time.Second)
+		i++
+	}
+}
+
+func getImageId(location string, imageName string, imageType string) string {
+	if imageName == "" {
+		return ""
+	}
+
+	SetAuth(os.Getenv("PROFITBRICKS_USERNAME"), os.Getenv("PROFITBRICKS_PASSWORD"))
+
+	images := ListImages()
+	if images.StatusCode > 299 {
+		fmt.Printf("Error while fetching the list of images %s", images.Response)
+	}
+
+	if len(images.Items) > 0 {
+		for _, i := range images.Items {
+			imgName := ""
+			if i.Properties.Name != "" {
+				imgName = i.Properties.Name
+			}
+
+			if imageType == "SSD" {
+				imageType = "HDD"
+			}
+			if imgName != "" && strings.Contains(strings.ToLower(imgName), strings.ToLower(imageName)) && i.Properties.ImageType == imageType && i.Properties.Location == location && i.Properties.Public == true {
+				return i.Id
+			}
+		}
+	}
+	return ""
+}

--- a/vendor/github.com/profitbricks/profitbricks-sdk-go/volume.go
+++ b/vendor/github.com/profitbricks/profitbricks-sdk-go/volume.go
@@ -1,0 +1,132 @@
+package profitbricks
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+)
+
+type Volume struct {
+	Id         string                     `json:"id,omitempty"`
+	Type_      string                     `json:"type,omitempty"`
+	Href       string                     `json:"href,omitempty"`
+	Metadata   *DatacenterElementMetadata `json:"metadata,omitempty"`
+	Properties VolumeProperties           `json:"properties,omitempty"`
+	Response   string                     `json:"Response,omitempty"`
+	Headers    *http.Header               `json:"headers,omitempty"`
+	StatusCode int                        `json:"headers,omitempty"`
+}
+
+type VolumeProperties struct {
+	Name                string   `json:"name,omitempty"`
+	Type                string   `json:"type,omitempty"`
+	Size                int      `json:"size,omitempty"`
+	AvailabilityZone    string   `json:"availabilityZone,omitempty"`
+	Image               string   `json:"image,omitempty"`
+	ImagePassword       string   `json:"imagePassword,omitempty"`
+	SshKeys             []string `json:"sshKeys,omitempty"`
+	Bus                 string   `json:"bus,omitempty"`
+	LicenceType         string   `json:"licenceType,omitempty"`
+	CpuHotPlug          bool     `json:"cpuHotPlug,omitempty"`
+	CpuHotUnplug        bool     `json:"cpuHotUnplug,omitempty"`
+	RamHotPlug          bool     `json:"ramHotPlug,omitempty"`
+	RamHotUnplug        bool     `json:"ramHotUnplug,omitempty"`
+	NicHotPlug          bool     `json:"nicHotPlug,omitempty"`
+	NicHotUnplug        bool     `json:"nicHotUnplug,omitempty"`
+	DiscVirtioHotPlug   bool     `json:"discVirtioHotPlug,omitempty"`
+	DiscVirtioHotUnplug bool     `json:"discVirtioHotUnplug,omitempty"`
+	DiscScsiHotPlug     bool     `json:"discScsiHotPlug,omitempty"`
+	DiscScsiHotUnplug   bool     `json:"discScsiHotUnplug,omitempty"`
+	DeviceNumber        int64    `json:"deviceNumber,omitempty"`
+}
+
+type Volumes struct {
+	Id         string       `json:"id,omitempty"`
+	Type_      string       `json:"type,omitempty"`
+	Href       string       `json:"href,omitempty"`
+	Items      []Volume     `json:"items,omitempty"`
+	Response   string       `json:"Response,omitempty"`
+	Headers    *http.Header `json:"headers,omitempty"`
+	StatusCode int          `json:"headers,omitempty"`
+}
+
+type CreateVolumeRequest struct {
+	VolumeProperties `json:"properties"`
+}
+
+// ListVolumes returns a Collection struct for volumes in the Datacenter
+func ListVolumes(dcid string) Volumes {
+	path := volume_col_path(dcid)
+	url := mk_url(path) + `?depth=` + Depth
+	req, _ := http.NewRequest("GET", url, nil)
+	req.Header.Add("Content-Type", FullHeader)
+	resp := do(req)
+	return toVolumes(resp)
+}
+
+func GetVolume(dcid string, volumeId string) Volume {
+	path := volume_path(dcid, volumeId)
+	url := mk_url(path) + `?depth=` + Depth
+	req, _ := http.NewRequest("GET", url, nil)
+	req.Header.Add("Content-Type", FullHeader)
+	resp := do(req)
+	return toVolume(resp)
+}
+
+func PatchVolume(dcid string, volid string, request VolumeProperties) Volume {
+	obj, _ := json.Marshal(request)
+	path := volume_path(dcid, volid)
+	url := mk_url(path) + `?depth=` + Depth
+	req, _ := http.NewRequest("PATCH", url, bytes.NewBuffer(obj))
+	req.Header.Add("Content-Type", PatchHeader)
+	return toVolume(do(req))
+}
+
+func CreateVolume(dcid string, request Volume) Volume {
+	obj, _ := json.Marshal(request)
+	path := volume_col_path(dcid)
+	url := mk_url(path) + `?depth=` + Depth
+	req, _ := http.NewRequest("POST", url, bytes.NewBuffer(obj))
+	req.Header.Add("Content-Type", FullHeader)
+	return toVolume(do(req))
+}
+
+func DeleteVolume(dcid, volid string) Resp {
+	path := volume_path(dcid, volid)
+	return is_delete(path)
+}
+
+func CreateSnapshot(dcid string, volid string, name string) Snapshot {
+	var path = volume_path(dcid, volid)
+	path = path + "/create-snapshot"
+	url := mk_url(path)
+	body := json.RawMessage("name=" + name)
+	req, _ := http.NewRequest("POST", url, bytes.NewBuffer(body))
+	req.Header.Add("Content-Type", CommandHeader)
+	return toSnapshot(do(req))
+}
+
+func RestoreSnapshot(dcid string, volid string, snapshotId string) Resp {
+	var path = volume_path(dcid, volid)
+	path = path + "/restore-snapshot"
+
+	return is_command(path, "snapshotId="+snapshotId)
+}
+
+func toVolume(resp Resp) Volume {
+	var server Volume
+	json.Unmarshal(resp.Body, &server)
+	server.Response = string(resp.Body)
+	server.Headers = &resp.Headers
+	server.StatusCode = resp.StatusCode
+	return server
+}
+
+func toVolumes(resp Resp) Volumes {
+	var col Volumes
+	json.Unmarshal(resp.Body, &col)
+	col.Response = string(resp.Body)
+	col.Headers = &resp.Headers
+	col.StatusCode = resp.StatusCode
+	return col
+}

--- a/vendor/github.com/profitbricks/profitbricks-sdk-go/volume_test.go
+++ b/vendor/github.com/profitbricks/profitbricks-sdk-go/volume_test.go
@@ -1,0 +1,106 @@
+package profitbricks
+
+import (
+	"fmt"
+	"testing"
+	"time"
+)
+
+var volumeId string
+
+func TestCreateVolume(t *testing.T) {
+	setupTestEnv()
+	want := 202
+	var request = Volume{
+		Properties: VolumeProperties{
+			Size:             5,
+			Name:             "Volume Test",
+			Image:            image,
+			Type:             "HDD",
+			ImagePassword:    "test1234",
+			AvailabilityZone: "ZONE_3",
+		},
+	}
+
+	dcID = mkdcid("GO SDK VOLUME DC")
+	resp := CreateVolume(dcID, request)
+
+	waitTillProvisioned(resp.Headers.Get("Location"))
+	volumeId = resp.Id
+	fmt.Println(resp.Properties.AvailabilityZone)
+	if resp.StatusCode != want {
+		fmt.Println(string(resp.Response))
+		t.Errorf(bad_status(want, resp.StatusCode))
+	}
+}
+
+func TestListVolumes(t *testing.T) {
+	want := 200
+	resp := ListVolumes(dcID)
+
+	if resp.StatusCode != want {
+		t.Errorf(bad_status(want, resp.StatusCode))
+	}
+}
+
+func TestGetVolume(t *testing.T) {
+	want := 200
+
+	resp := GetVolume(dcID, volumeId)
+	fmt.Println(dcID)
+	fmt.Println(volumeId)
+	if resp.StatusCode != want {
+		t.Errorf(bad_status(want, resp.StatusCode))
+	}
+}
+
+func TestPatchVolume(t *testing.T) {
+	want := 202
+	obj := VolumeProperties{
+		Name: "Renamed Volume",
+		Size: 2,
+	}
+
+	resp := PatchVolume(dcID, volumeId, obj)
+
+	if resp.StatusCode != want {
+		fmt.Println(string(resp.Response))
+		t.Errorf(bad_status(want, resp.StatusCode))
+	}
+}
+
+func TestCreateSnapshot(t *testing.T) {
+	want := 202
+
+	resp := CreateSnapshot(dcID, volumeId, "testSnapshot")
+	waitTillProvisioned(resp.Headers.Get("Location"))
+	if resp.StatusCode != want {
+		fmt.Println(string(resp.Response))
+		t.Errorf(bad_status(want, resp.StatusCode))
+	}
+	time.Sleep(30 * time.Second)
+	snapshotId = resp.Id
+}
+
+func TestRestoreSnapshot(t *testing.T) {
+	want := 202
+
+	resp := RestoreSnapshot(dcID, volumeId, snapshotId)
+
+	waitTillProvisioned(resp.Headers.Get("Location"))
+	if resp.StatusCode != want {
+		fmt.Println(string(resp.Body))
+		t.Errorf(bad_status(want, resp.StatusCode))
+	}
+}
+
+func TestCleanup(t *testing.T) {
+	fmt.Println("CLEANING UP AFTER SNAPSHOTS")
+	resp := DeleteSnapshot(snapshotId)
+	fmt.Println(resp.StatusCode)
+	fmt.Println("CLEANING UP AFTER VOLUMES")
+	resp = DeleteVolume(dcID, volumeId)
+	fmt.Println(resp.StatusCode)
+	resp = DeleteDatacenter(dcID)
+	fmt.Println(resp.StatusCode)
+}


### PR DESCRIPTION
Here is the implementation for a new backend, [ProfitBricks](https://www.profitbricks.com/).  I’ve modeled the driver after the EBS and DigitalOcean implementations.

README.md has been updated where necessary, and I’ve also created driver-specific documentation at `docs/profitbricks.md`.  Unit tests can be found in the `profitbricks_test.go`.

Overall, functional testing went very well.  I have found that the `MountPoint` field is never populated for any of the volumes I create, although the daemon does log something to the effect of: 
```
DEBU[2233] Response:  {
	"Mountpoint": "/var/lib/rancher/convoy/profitbricks/mounts/apples"
}  pkg=daemon
```

I’ve also run into an issue with the Docker integration, which may stem from the mount point issue above.  If I try an example like the one below, my data does not persist from the original volume to the one created by snapshot.

```
root@ubuntu:~# docker run -it -v volume1:/volume1 --volume-driver=convoy ubuntu
root@c7d73b8733e9:/# touch /volume1/foo
root@c7d73b8733e9:/# exit
exit
root@ubuntu:~# convoy snapshot create volume1 --name "volume1_snapshot"
volume1_snapshot
root@ubuntu:~# convoy create volume2 --backup "UUID of snapshot from above"
volume2
root@ubuntu:~# docker run -it -v volume2:/volume2 --volume-driver=convoy ubuntu
root@4b3a4ef0d35a:/# ls /volume2/foo
ls: cannot access '/volume2/foo': No such file or directory
root@4b3a4ef0d35a:/# exit
exit
```

Please let me know your thoughts, and advise of any changes that you would like to be made on my end.  Thanks in advance.

@yasker