### PR TITLE
Add custom endpoint capability

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,8 @@
+.dapper
+.trash-cache
+*.pyc
+__pycache__/
+
 # Compiled Object files, Static and Dynamic libs (Shared Objects)
 *.o
 *.a

--- a/api/request.go
+++ b/api/request.go
@@ -15,6 +15,7 @@ type VolumeCreateRequest struct {
 	DriverName     string
 	Size           int64
 	BackupURL      string
+	Endpoint       string
 	DriverVolumeID string
 	Type           string
 	IOPS           int64
@@ -47,16 +48,19 @@ type SnapshotInspectRequest struct {
 
 type BackupListRequest struct {
 	URL          string
+	Endpoint     string
 	VolumeName   string
 	SnapshotName string
 }
 
 type BackupCreateRequest struct {
 	URL          string
+	Endpoint     string
 	SnapshotName string
 	Verbose      bool
 }
 
 type BackupDeleteRequest struct {
-	URL string
+	URL      string
+	Endpoint string
 }

--- a/client/client.go
+++ b/client/client.go
@@ -38,7 +38,7 @@ func (c *convoyClient) call(method, path string, data interface{}, headers map[s
 		if headers == nil {
 			headers = make(map[string][]string)
 		}
-		headers["Context-Type"] = []string{"application/json"}
+		headers["Content-Type"] = []string{"application/json"}
 	}
 
 	body, _, statusCode, err := c.clientRequest(method, path, params, headers)
@@ -77,11 +77,11 @@ func (c *convoyClient) clientRequest(method, path string, in io.Reader, headers 
 			return nil, "", statusCode, err
 		}
 		if len(body) == 0 {
-			return nil, "", statusCode, fmt.Errorf("Incompatable version")
+			return nil, "", statusCode, fmt.Errorf("Incompatible version")
 		}
 		return nil, "", statusCode, fmt.Errorf("Error response from server, %v", string(body))
 	}
-	return resp.Body, resp.Header.Get("Context-Type"), statusCode, nil
+	return resp.Body, resp.Header.Get("Content-Type"), statusCode, nil
 }
 
 func sendRequest(method, request string, data interface{}) (io.ReadCloser, error) {

--- a/client/objectstore.go
+++ b/client/objectstore.go
@@ -7,6 +7,11 @@ import (
 )
 
 var (
+	S3EndpointFlag = cli.StringFlag{
+		Name:  "s3-endpoint",
+		Usage: "custom S3 endpoint URL, like http://minio.example.com:9000",
+	}
+
 	backupCreateCmd = cli.Command{
 		Name:  "create",
 		Usage: "create a backup in objectstore: create <snapshot>",
@@ -52,6 +57,9 @@ var (
 			backupListCmd,
 			backupInspectCmd,
 		},
+		Flags: []cli.Flag{
+			S3EndpointFlag,
+		},
 	}
 )
 
@@ -70,8 +78,10 @@ func doBackupList(c *cli.Context) error {
 		return err
 	}
 
+	endpointURL := c.GlobalString("s3-endpoint")
 	request := &api.BackupListRequest{
 		URL:        destURL,
+		Endpoint:   endpointURL,
 		VolumeName: volumeName,
 	}
 	url := "/backups/list"
@@ -92,8 +102,10 @@ func doBackupInspect(c *cli.Context) error {
 		return err
 	}
 
+	endpointURL := c.GlobalString("s3-endpoint")
 	request := &api.BackupListRequest{
-		URL: backupURL,
+		URL:      backupURL,
+		Endpoint: endpointURL,
 	}
 	url := "/backups/inspect"
 	return sendRequestAndPrint("GET", url, request)
@@ -118,8 +130,10 @@ func doBackupCreate(c *cli.Context) error {
 		return err
 	}
 
+	endpointURL := c.GlobalString("s3-endpoint")
 	request := &api.BackupCreateRequest{
 		URL:          destURL,
+		Endpoint:     endpointURL,
 		SnapshotName: snapshotName,
 		Verbose:      c.GlobalBool(verboseFlag),
 	}
@@ -141,8 +155,10 @@ func doBackupDelete(c *cli.Context) error {
 		return err
 	}
 
+	endpointURL := c.GlobalString("s3-endpoint")
 	request := &api.BackupDeleteRequest{
-		URL: backupURL,
+		URL:      backupURL,
+		Endpoint: endpointURL,
 	}
 	url := "/backups"
 	return sendRequestAndPrint("DELETE", url, request)

--- a/client/volume.go
+++ b/client/volume.go
@@ -26,6 +26,7 @@ var (
 				Name:  "backup",
 				Usage: "create a volume of backup if driver supports",
 			},
+			S3EndpointFlag,
 			cli.StringFlag{
 				Name:  "id",
 				Usage: "driver specific volume ID if driver supports",
@@ -120,6 +121,7 @@ func doVolumeCreate(c *cli.Context) error {
 		return err
 	}
 
+	endpointURL := c.String("s3-endpoint")
 	driverVolumeID := c.String("id")
 	volumeType := c.String("type")
 	iops := c.Int("iops")
@@ -130,6 +132,7 @@ func doVolumeCreate(c *cli.Context) error {
 		DriverName:     driverName,
 		Size:           size,
 		BackupURL:      backupURL,
+		Endpoint:       endpointURL,
 		DriverVolumeID: driverVolumeID,
 		Type:           volumeType,
 		IOPS:           int64(iops),

--- a/convoydriver/convoydriver.go
+++ b/convoydriver/convoydriver.go
@@ -75,10 +75,10 @@ VolumeOperations.CreateVolume() with opts[OPT_BACKUP_URL]
 */
 type BackupOperations interface {
 	Name() string
-	CreateBackup(snapshotID, volumeID, destURL string, opts map[string]string) (string, error)
-	DeleteBackup(backupURL string) error
-	GetBackupInfo(backupURL string) (map[string]string, error)
-	ListBackup(destURL string, opts map[string]string) (map[string]map[string]string, error)
+	CreateBackup(snapshotID, volumeID, destURL, endpointURL string, opts map[string]string) (string, error)
+	DeleteBackup(backupURL, endpointURL string) error
+	GetBackupInfo(backupURL, endpointURL string) (map[string]string, error)
+	ListBackup(destURL, endpointURL string, opts map[string]string) (map[string]map[string]string, error)
 }
 
 const (
@@ -93,6 +93,7 @@ const (
 	OPT_SNAPSHOT_NAME         = "SnapshotName"
 	OPT_SNAPSHOT_CREATED_TIME = "SnapshotCreatedAt"
 	OPT_BACKUP_URL            = "BackupURL"
+	OPT_ENDPOINT_URL          = "EndpointURL"
 	OPT_REFERENCE_ONLY        = "ReferenceOnly"
 	OPT_PREPARE_FOR_VM        = "PrepareForVM"
 	OPT_FILESYSTEM            = "Filesystem"

--- a/daemon/docker.go
+++ b/daemon/docker.go
@@ -89,6 +89,7 @@ func (s *daemon) createDockerVolume(request *pluginRequest) (*Volume, error) {
 		DriverName:     request.Opts["driver"],
 		Size:           size,
 		BackupURL:      request.Opts["backup"],
+		Endpoint:       request.Opts["endpoint"],
 		DriverVolumeID: request.Opts["id"],
 		Type:           request.Opts["type"],
 		PrepareForVM:   prepareForVM,

--- a/devmapper/backup.go
+++ b/devmapper/backup.go
@@ -122,7 +122,7 @@ func (d *Driver) ReadSnapshot(id, volumeID string, offset int64, data []byte) er
 	return nil
 }
 
-func (d *Driver) CreateBackup(snapshotID, volumeID, destURL string, opts map[string]string) (string, error) {
+func (d *Driver) CreateBackup(snapshotID, volumeID, destURL, endpointURL string, opts map[string]string) (string, error) {
 	d.mutex.Lock()
 	defer d.mutex.Unlock()
 
@@ -141,40 +141,40 @@ func (d *Driver) CreateBackup(snapshotID, volumeID, destURL string, opts map[str
 		Name:        snapshotID,
 		CreatedTime: opts[convoydriver.OPT_SNAPSHOT_CREATED_TIME],
 	}
-	return objectstore.CreateDeltaBlockBackup(objVolume, objSnapshot, destURL, d)
+	return objectstore.CreateDeltaBlockBackup(objVolume, objSnapshot, destURL, endpointURL, d)
 }
 
-func (d *Driver) DeleteBackup(backupURL string) error {
+func (d *Driver) DeleteBackup(backupURL, endpointURL string) error {
 	d.mutex.Lock()
 	defer d.mutex.Unlock()
 
-	objVolume, err := objectstore.LoadVolume(backupURL)
+	objVolume, err := objectstore.LoadVolume(backupURL, endpointURL)
 	if err != nil {
 		return err
 	}
 	if objVolume.Driver != d.Name() {
 		return fmt.Errorf("BUG: Wrong driver handling DeleteBackup(), driver should be %v but is %v", objVolume.Driver, d.Name())
 	}
-	return objectstore.DeleteDeltaBlockBackup(backupURL)
+	return objectstore.DeleteDeltaBlockBackup(backupURL, endpointURL)
 }
 
-func (d *Driver) GetBackupInfo(backupURL string) (map[string]string, error) {
+func (d *Driver) GetBackupInfo(backupURL, endpointURL string) (map[string]string, error) {
 	d.mutex.RLock()
 	defer d.mutex.RUnlock()
 
-	objVolume, err := objectstore.LoadVolume(backupURL)
+	objVolume, err := objectstore.LoadVolume(backupURL, endpointURL)
 	if err != nil {
 		return nil, err
 	}
 	if objVolume.Driver != d.Name() {
 		return nil, fmt.Errorf("BUG: Wrong driver handling DeleteBackup(), driver should be %v but is %v", objVolume.Driver, d.Name())
 	}
-	return objectstore.GetBackupInfo(backupURL)
+	return objectstore.GetBackupInfo(backupURL, endpointURL)
 }
 
-func (d *Driver) ListBackup(destURL string, opts map[string]string) (map[string]map[string]string, error) {
+func (d *Driver) ListBackup(destURL, endpointURL string, opts map[string]string) (map[string]map[string]string, error) {
 	d.mutex.RLock()
 	defer d.mutex.RUnlock()
 
-	return objectstore.List(opts[convoydriver.OPT_VOLUME_NAME], destURL, d.Name())
+	return objectstore.List(opts[convoydriver.OPT_VOLUME_NAME], destURL, endpointURL, d.Name())
 }

--- a/devmapper/devmapper.go
+++ b/devmapper/devmapper.go
@@ -437,8 +437,9 @@ func (d *Driver) CreateVolume(req Request) error {
 	opts := req.Options
 
 	backupURL := opts[OPT_BACKUP_URL]
+	endpointURL := opts[OPT_ENDPOINT_URL]
 	if backupURL != "" {
-		objVolume, err := objectstore.LoadVolume(backupURL)
+		objVolume, err := objectstore.LoadVolume(backupURL, endpointURL)
 		if err != nil {
 			return err
 		}
@@ -538,7 +539,7 @@ func (d *Driver) CreateVolume(req Request) error {
 			return err
 		}
 	} else {
-		if err := objectstore.RestoreDeltaBlockBackup(backupURL, dev); err != nil {
+		if err := objectstore.RestoreDeltaBlockBackup(backupURL, endpointURL, dev); err != nil {
 			return err
 		}
 	}

--- a/logging/logging.go
+++ b/logging/logging.go
@@ -16,6 +16,7 @@ const (
 	LOG_FIELD_LAST_SNAPSHOT = "last_snapshot"
 	LOG_FIELD_BACKUP_URL    = "backup_url"
 	LOG_FIELD_DEST_URL      = "dest_url"
+	LOG_FIELD_ENDPOINT_URL  = "endpoint_url"
 	LOG_FIELD_MOUNTPOINT    = "mountpoint"
 	LOG_FIELD_NAMESPACE     = "namespace"
 	LOG_FIELD_CFG           = "config_file"

--- a/objectstore/deltablock.go
+++ b/objectstore/deltablock.go
@@ -34,12 +34,12 @@ const (
 	BLOCK_SEPARATE_LAYER2 = 4
 )
 
-func CreateDeltaBlockBackup(volume *Volume, snapshot *Snapshot, destURL string, deltaOps DeltaBlockBackupOperations) (string, error) {
+func CreateDeltaBlockBackup(volume *Volume, snapshot *Snapshot, destURL, endpoint string, deltaOps DeltaBlockBackupOperations) (string, error) {
 	if deltaOps == nil {
 		return "", fmt.Errorf("Missing DeltaBlockBackupOperations")
 	}
 
-	bsDriver, err := GetObjectStoreDriver(destURL)
+	bsDriver, err := GetObjectStoreDriver(destURL, endpoint)
 	if err != nil {
 		return "", err
 	}
@@ -229,8 +229,8 @@ func mergeSnapshotMap(deltaBackup, lastBackup *Backup) *Backup {
 	return backup
 }
 
-func RestoreDeltaBlockBackup(backupURL, volDevName string) error {
-	bsDriver, err := GetObjectStoreDriver(backupURL)
+func RestoreDeltaBlockBackup(backupURL, endpoint, volDevName string) error {
+	bsDriver, err := GetObjectStoreDriver(backupURL, endpoint)
 	if err != nil {
 		return err
 	}
@@ -309,8 +309,8 @@ func RestoreDeltaBlockBackup(backupURL, volDevName string) error {
 	return nil
 }
 
-func DeleteDeltaBlockBackup(backupURL string) error {
-	bsDriver, err := GetObjectStoreDriver(backupURL)
+func DeleteDeltaBlockBackup(backupURL, endpoint string) error {
+	bsDriver, err := GetObjectStoreDriver(backupURL, endpoint)
 	if err != nil {
 		return err
 	}

--- a/objectstore/objectstore.go
+++ b/objectstore/objectstore.go
@@ -113,8 +113,8 @@ func addListVolume(resp map[string]map[string]string, volumeName string, driver 
 	return nil
 }
 
-func List(volumeName, destURL, storageDriverName string) (map[string]map[string]string, error) {
-	driver, err := GetObjectStoreDriver(destURL)
+func List(volumeName, destURL, endpointURL, storageDriverName string) (map[string]map[string]string, error) {
+	driver, err := GetObjectStoreDriver(destURL, endpointURL)
 	if err != nil {
 		return nil, err
 	}
@@ -151,8 +151,8 @@ func fillBackupInfo(backup *Backup, volume *Volume, destURL string) map[string]s
 	}
 }
 
-func GetBackupInfo(backupURL string) (map[string]string, error) {
-	driver, err := GetObjectStoreDriver(backupURL)
+func GetBackupInfo(backupURL, endpointURL string) (map[string]string, error) {
+	driver, err := GetObjectStoreDriver(backupURL, endpointURL)
 	if err != nil {
 		return nil, err
 	}
@@ -173,12 +173,12 @@ func GetBackupInfo(backupURL string) (map[string]string, error) {
 	return fillBackupInfo(backup, volume, driver.GetURL()), nil
 }
 
-func LoadVolume(backupURL string) (*Volume, error) {
+func LoadVolume(backupURL, endpointURL string) (*Volume, error) {
 	_, volumeName, err := decodeBackupURL(backupURL)
 	if err != nil {
 		return nil, err
 	}
-	driver, err := GetObjectStoreDriver(backupURL)
+	driver, err := GetObjectStoreDriver(backupURL, endpointURL)
 	if err != nil {
 		return nil, err
 	}

--- a/objectstore/singlefile.go
+++ b/objectstore/singlefile.go
@@ -23,8 +23,8 @@ func getSingleFileBackupFilePath(sfBackup *Backup) string {
 	return filepath.Join(getVolumePath(sfBackup.VolumeName), BACKUP_FILES_DIRECTORY, backupFileName)
 }
 
-func CreateSingleFileBackup(volume *Volume, snapshot *Snapshot, filePath, destURL string) (string, error) {
-	driver, err := GetObjectStoreDriver(destURL)
+func CreateSingleFileBackup(volume *Volume, snapshot *Snapshot, filePath, destURL, endpoint string) (string, error) {
+	driver, err := GetObjectStoreDriver(destURL, endpoint)
 	if err != nil {
 		return "", err
 	}
@@ -73,8 +73,8 @@ func CreateSingleFileBackup(volume *Volume, snapshot *Snapshot, filePath, destUR
 	return encodeBackupURL(backup.Name, volume.Name, destURL), nil
 }
 
-func RestoreSingleFileBackup(backupURL, path string) (string, error) {
-	driver, err := GetObjectStoreDriver(backupURL)
+func RestoreSingleFileBackup(backupURL, endpoint, path string) (string, error) {
+	driver, err := GetObjectStoreDriver(backupURL, endpoint)
 	if err != nil {
 		return "", err
 	}
@@ -104,8 +104,8 @@ func RestoreSingleFileBackup(backupURL, path string) (string, error) {
 	return dstFile, nil
 }
 
-func DeleteSingleFileBackup(backupURL string) error {
-	driver, err := GetObjectStoreDriver(backupURL)
+func DeleteSingleFileBackup(backupURL, endpoint string) error {
+	driver, err := GetObjectStoreDriver(backupURL, endpoint)
 	if err != nil {
 		return err
 	}

--- a/s3/s3_service.go
+++ b/s3/s3_service.go
@@ -11,12 +11,21 @@ import (
 )
 
 type S3Service struct {
-	Region string
-	Bucket string
+	Region   string
+	Bucket   string
+	Endpoint string
 }
 
 func (s *S3Service) New() (*s3.S3, error) {
-	return s3.New(session.New(), &aws.Config{Region: &s.Region}), nil
+	config := aws.NewConfig().
+		WithRegion(s.Region)
+
+	if s.Endpoint != "" {
+		config = config.
+			WithEndpoint(s.Endpoint).
+			WithS3ForcePathStyle(true)
+	}
+	return s3.New(session.New(), config), nil
 }
 
 func (s *S3Service) Close() {

--- a/s3/s3_test.go
+++ b/s3/s3_test.go
@@ -1,0 +1,138 @@
+package s3
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/rancher/convoy/objectstore"
+	"gopkg.in/check.v1"
+)
+
+var (
+	errFakeConnection = errors.New("Simulated connection error")
+)
+
+func TestS3(t *testing.T) { check.TestingT(t) }
+
+type S3TestSuite struct{}
+
+var _ = check.Suite(&S3TestSuite{})
+
+func runInitFunc(c *check.C, destURL, endpoint string, makeConnectionError bool) (bool, objectstore.ObjectStoreDriver, error) {
+	attemptedConnection := false
+	fakeConnectionTest := func(d objectstore.ObjectStoreDriver) error {
+		attemptedConnection = true
+		if makeConnectionError {
+			return errFakeConnection
+		}
+		return nil
+	}
+
+	driver, err := initFuncWithConnectionCheck(destURL, endpoint, fakeConnectionTest)
+	return attemptedConnection, driver, err
+}
+
+func (s *S3TestSuite) TestInitFuncBasicURL(c *check.C) {
+	attemptedConnection, driver, err := runInitFunc(c, "s3://test@us-east-1/path", "", false)
+	expectedDriver := S3ObjectStoreDriver{
+		destURL: "s3://test@us-east-1/path",
+		path:    "path",
+		service: S3Service{
+			Bucket: "test",
+			Region: "us-east-1",
+		},
+	}
+
+	c.Check(err, check.IsNil)
+	c.Check(attemptedConnection, check.Equals, true)
+	c.Check(&expectedDriver, check.DeepEquals, driver)
+}
+
+func (s *S3TestSuite) TestInitFuncNoPath(c *check.C) {
+	attemptedConnection, driver, err := runInitFunc(c, "s3://test@us-east-1/", "", false)
+	expectedDriver := S3ObjectStoreDriver{
+		destURL: "s3://test@us-east-1/",
+		service: S3Service{
+			Bucket: "test",
+			Region: "us-east-1",
+		},
+	}
+
+	c.Check(err, check.IsNil)
+	c.Check(attemptedConnection, check.Equals, true)
+	c.Check(&expectedDriver, check.DeepEquals, driver)
+}
+
+func (s *S3TestSuite) TestInitFuncNoRegion(c *check.C) {
+	attemptedConnection, driver, err := runInitFunc(c, "s3://test/", "", false)
+	expectedDriver := S3ObjectStoreDriver{
+		destURL: "s3://test/",
+		service: S3Service{Bucket: "test"},
+	}
+
+	c.Check(err, check.IsNil)
+	c.Check(attemptedConnection, check.Equals, true)
+	c.Check(&expectedDriver, check.DeepEquals, driver)
+}
+
+func (s *S3TestSuite) TestInitFuncCustomEndpoint(c *check.C) {
+	attemptedConnection, driver, err := runInitFunc(c, "s3://test@us-east-1/", "http://example.com", false)
+	expectedDriver := S3ObjectStoreDriver{
+		destURL: "s3://test@us-east-1/",
+		service: S3Service{
+			Bucket:   "test",
+			Endpoint: "http://example.com",
+			Region:   "us-east-1",
+		},
+	}
+
+	c.Check(err, check.IsNil)
+	c.Check(attemptedConnection, check.Equals, true)
+	c.Check(&expectedDriver, check.DeepEquals, driver)
+}
+
+func (s *S3TestSuite) TestInitFuncBasicURLConnectionError(c *check.C) {
+	_, _, err := runInitFunc(c, "s3://test@us-east-1/", "", true)
+	c.Check(err, check.Equals, errFakeConnection)
+}
+
+func (s *S3TestSuite) TestInitFuncCustomEndpointConnectionError(c *check.C) {
+	_, _, err := runInitFunc(c, "s3://test@us-east-1/", "http://example.com", true)
+	c.Check(err, check.Equals, errFakeConnection)
+}
+
+func (s *S3TestSuite) TestInitFuncBadURL(c *check.C) {
+	_, _, err := runInitFunc(c, ":", "", false)
+	c.Check(err, check.NotNil)
+}
+
+func (s *S3TestSuite) TestInitFuncBadURLScheme(c *check.C) {
+	_, _, err := runInitFunc(c, "http://test@us-east-1/", "", false)
+	c.Check(err, check.NotNil)
+}
+
+func (s *S3TestSuite) TestInitFuncBadURLBucket(c *check.C) {
+	_, _, err := runInitFunc(c, "s3://@us-east-1/", "", false)
+	c.Check(err, check.NotNil)
+}
+
+func (s *S3TestSuite) TestInitFuncBadEndpointURL(c *check.C) {
+	_, _, err := runInitFunc(c, "s3://test@us-east-1/", ":", false)
+	c.Check(err, check.NotNil)
+}
+
+func (s *S3TestSuite) TestInitFuncTrimLeadingSlashes(c *check.C) {
+	attemptedConnection, driver, err := runInitFunc(c, "s3://test@us-east-1////path", "", false)
+	expectedDriver := S3ObjectStoreDriver{
+		destURL: "s3://test@us-east-1/path",
+		path:    "path",
+		service: S3Service{
+			Bucket: "test",
+			Region: "us-east-1",
+		},
+	}
+
+	c.Check(err, check.IsNil)
+	c.Check(attemptedConnection, check.Equals, true)
+	c.Check(&expectedDriver, check.DeepEquals, driver)
+}

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -2,8 +2,6 @@
 
 import pytest
 def pytest_addoption(parser):
-    parser.addoption("--s3", action="store_true",
-            help="enable S3 test. You would be billed for this.")
     parser.addoption("--ebs", action="store_true",
             help="enable EBS test. Must be on EC2 instance. You would be billed for this")
     parser.addoption("--container", action="store_true",

--- a/tests/integration/convoy.py
+++ b/tests/integration/convoy.py
@@ -7,11 +7,11 @@ import json
 class VolumeManager:
     def __init__(self, base_cmdline, mount_root):
         self.base_cmdline = base_cmdline
-	self.mount_root = mount_root
+        self.mount_root = mount_root
 
     def start_server(self, pidfile, cmdline):
         start_cmdline = ["start-stop-daemon", "-S", "-b", "-m", "-p", pidfile,
-			"--exec"] + self.base_cmdline + ["--"] + cmdline
+                        "--exec"] + self.base_cmdline + ["--"] + cmdline
         subprocess.check_call(start_cmdline)
 
     def stop_server(self, pidfile):
@@ -31,7 +31,7 @@ class VolumeManager:
                         "-v", "/proc:/host/proc",
                         "-v", cfg_root + ":" + cfg_root,
                         "-v", file_root + ":" + file_root,
-			container,
+                        container,
                         ] + cmdline
         return subprocess.check_call(start_cmdline)
 
@@ -45,7 +45,7 @@ class VolumeManager:
         return output.startswith("true")
  
     def server_info(self):
-	return subprocess.check_output(self.base_cmdline + ["info"])
+        return subprocess.check_output(self.base_cmdline + ["info"])
 
     def create_volume(self, size = "", name = "", backup = "", driver = "",
                     volume_id = "", volume_type = "", iops = "", forvm = False):
@@ -72,36 +72,36 @@ class VolumeManager:
     def delete_volume(self, volume, ref_only = False):
         cmdline = self.base_cmdline + ["delete", volume]
         if ref_only:
-                cmdline += ["--reference"]
+            cmdline += ["--reference"]
         subprocess.check_call(cmdline)
 
     def mount_volume_with_path(self, volume):
         volume_mount_dir = os.path.join(self.mount_root, volume)
         if not os.path.exists(volume_mount_dir):
-    	    os.makedirs(volume_mount_dir)
+            os.makedirs(volume_mount_dir)
         assert os.path.exists(volume_mount_dir)
         cmdline = self.base_cmdline + ["mount", volume,
-    		"--mountpoint", volume_mount_dir]
-	subprocess.check_call(cmdline)
+                    "--mountpoint", volume_mount_dir]
+        subprocess.check_call(cmdline)
         return volume_mount_dir
 
     def mount_volume(self, volume):
         cmdline = self.base_cmdline + ["mount", volume]
 
-	data = subprocess.check_output(cmdline)
+        data = subprocess.check_output(cmdline)
         return data.strip()
 
     def umount_volume(self, volume):
         subprocess.check_call(self.base_cmdline + ["umount", volume])
 
     def list_volumes(self):
-    	data = subprocess.check_output(self.base_cmdline + ["list"])
+        data = subprocess.check_output(self.base_cmdline + ["list"])
         volumes = json.loads(data)
         return volumes
 
     def inspect_volume(self, volume):
         cmd = ["inspect", volume]
-    	data = subprocess.check_output(self.base_cmdline + cmd)
+        data = subprocess.check_output(self.base_cmdline + cmd)
 
         return json.loads(data)
 
@@ -130,18 +130,18 @@ class VolumeManager:
         return data.strip()
 
     def delete_backup(self, backup):
-	subprocess.check_call(self.base_cmdline + ["backup", "delete", backup])
+        subprocess.check_call(self.base_cmdline + ["backup", "delete", backup])
 
     def list_backup(self, dest, volume_name = ""):
         cmd = ["backup", "list", dest]
         if volume_name != "":
-		cmd += ["--volume-name", volume_name]
-	data = subprocess.check_output(self.base_cmdline + cmd)
+            cmd += ["--volume-name", volume_name]
+        data = subprocess.check_output(self.base_cmdline + cmd)
         backups = json.loads(data)
         return backups
 
     def inspect_backup(self, backup):
-	data = subprocess.check_output(self.base_cmdline + ["backup",
-                "inspect", backup])
+        data = subprocess.check_output(self.base_cmdline + ["backup",
+            "inspect", backup])
         backups = json.loads(data)
         return backups

--- a/tests/integration/convoy.py
+++ b/tests/integration/convoy.py
@@ -10,16 +10,17 @@ class VolumeManager:
         self.mount_root = mount_root
 
     def start_server(self, pidfile, cmdline):
-        start_cmdline = ["start-stop-daemon", "-S", "-b", "-m", "-p", pidfile,
+        start_cmdline = ["start-stop-daemon", "--start", "--background",
+                        "--make-pidfile", "--pidfile", pidfile,
                         "--exec"] + self.base_cmdline + ["--"] + cmdline
         subprocess.check_call(start_cmdline)
 
     def stop_server(self, pidfile):
-        stop_cmdline = ["start-stop-daemon", "-K", "-p", pidfile, "-x"] + self.base_cmdline
+        stop_cmdline = ["start-stop-daemon", "--stop", "--pidfile", pidfile, "--exec"] + self.base_cmdline
         return subprocess.call(stop_cmdline)
 
     def check_server(self, pidfile):
-        check_cmdline = ["start-stop-daemon", "-T", "-p", pidfile]
+        check_cmdline = ["start-stop-daemon", "--status", "--pidfile", pidfile]
         return subprocess.call(check_cmdline)
 
     def start_server_container(self, name, cfg_root, file_root, container, cmdline):

--- a/tests/integration/s3.py
+++ b/tests/integration/s3.py
@@ -1,0 +1,36 @@
+#!/usr/bin/env python
+
+import subprocess
+
+
+MINIO_VERSION = "RELEASE.2018-11-30T03-56-59Z"
+
+
+class S3Server:
+    def __init__(self, access_key, secret_key, name="convoy_minio", port=9000):
+        self.access_key = access_key
+        self.secret_key = secret_key
+        self.name = name
+        self.port = port
+
+    def start(self):
+        cmd = [
+            "docker", "run", "--detach",
+            "--name", self.name,
+            "--publish", "%d:9000" % self.port,
+            "--env", "MINIO_ACCESS_KEY=" + self.access_key,
+            "--env", "MINIO_SECRET_KEY=" + self.secret_key,
+            "minio/minio:" + MINIO_VERSION, "server", "/data",
+        ]
+        return subprocess.check_call(cmd)
+
+    def make_bucket(self, bucket):
+        return subprocess.check_call(["docker", "exec", self.name,
+                                     "sh", "-c", "mkdir -p /data/" + bucket])
+
+    def stop(self):
+        return subprocess.check_call(["docker", "rm", "--force",
+                                     "--volumes", self.name])
+
+    def connection_str(self):
+        return "http://localhost:%d/" % self.port

--- a/tests/integration/test_main.py
+++ b/tests/integration/test_main.py
@@ -106,7 +106,7 @@ def setup_module():
     test_container = pytest.config.getoption("container")
 
     if os.path.exists(TEST_ROOT):
-	subprocess.check_call(["rm", "-rf", TEST_ROOT])
+        subprocess.check_call(["rm", "-rf", TEST_ROOT])
 
     os.makedirs(TEST_ROOT)
     assert os.path.exists(TEST_ROOT)
@@ -138,8 +138,8 @@ def setup_module():
         "--log", LOG_FILE,
         "--drivers=" + DM,
         "--driver-opts", "dm.datadev=" + data_dev,
-	"--driver-opts", "dm.metadatadev=" + metadata_dev,
-	"--driver-opts", "dm.thinpoolname=" + POOL_NAME,
+        "--driver-opts", "dm.metadatadev=" + metadata_dev,
+        "--driver-opts", "dm.thinpoolname=" + POOL_NAME,
         "--driver-opts", "dm.defaultvolumesize=" + DEFAULT_VOLUME_SIZE,
         "--drivers=" + VFS,
         "--driver-opts", "vfs.path=" + VFS_VOLUME_PATH]
@@ -338,7 +338,7 @@ def test_vfs_delete_volume_ref_only():
     filename = "testfile"
     test_file = os.path.join(path,filename)
     with open(test_file, "w") as f:
-	subprocess.check_call(["echo", "This is volume test file"], stdout=f)
+        subprocess.check_call(["echo", "This is volume test file"], stdout=f)
     assert os.path.exists(test_file)
 
     delete_volume(name, ref_only = True)
@@ -385,7 +385,7 @@ def mount_volume_and_create_file(name, filename):
 
     test_file = os.path.join(volume_mount_dir,filename)
     with open(test_file, "w") as f:
-	subprocess.check_call(["echo", "This is volume test file"], stdout=f)
+        subprocess.check_call(["echo", "This is volume test file"], stdout=f)
     assert os.path.exists(test_file)
 
     umount_volume(name, volume_mount_dir)
@@ -452,17 +452,17 @@ def volume_list_driver_test(drv, check_size = True):
     vol1 = create_volume(driver=drv)
     vol2 = create_volume(driver=drv)
     if check_size:
-	vol3 = create_volume(VOLUME_SIZE_BIG, driver=drv)
-	vol4 = create_volume(VOLUME_SIZE_SMALL, driver=drv)
+        vol3 = create_volume(VOLUME_SIZE_BIG, driver=drv)
+        vol4 = create_volume(VOLUME_SIZE_SMALL, driver=drv)
 
     volume = v.inspect_volume(vol1)
     assert volume["Name"] == vol1
     if check_size:
-	assert volume["DriverInfo"]["Size"] == DEFAULT_VOLUME_SIZE
+        assert volume["DriverInfo"]["Size"] == DEFAULT_VOLUME_SIZE
     volume = v.inspect_volume(vol2)
     assert volume["Name"] == vol2
     if check_size:
-	assert volume["DriverInfo"]["Size"] == DEFAULT_VOLUME_SIZE
+        assert volume["DriverInfo"]["Size"] == DEFAULT_VOLUME_SIZE
 
     if check_size:
         volumes = v.list_volumes()
@@ -471,8 +471,8 @@ def volume_list_driver_test(drv, check_size = True):
         assert volumes[vol3]["DriverInfo"]["Size"] == VOLUME_SIZE_BIG_Bytes
         assert volumes[vol4]["DriverInfo"]["Size"] == VOLUME_SIZE_SMALL
 
-	delete_volume(vol4)
-	delete_volume(vol3)
+        delete_volume(vol4)
+        delete_volume(vol3)
 
     delete_volume(vol2)
     delete_volume(vol1)
@@ -517,7 +517,7 @@ def snapshot_name_test(driver):
     assert s["CreatedTime"] != ""
 
     with pytest.raises(subprocess.CalledProcessError):
-	    new_name = v.create_snapshot(volume_name, name=snap1_name)
+            new_name = v.create_snapshot(volume_name, name=snap1_name)
 
     v.delete_snapshot(snap1)
     delete_volume(volume_name)
@@ -635,7 +635,7 @@ def test_create_volume_in_parallel():
 
 def test_create_volume_in_sequence():
     for i in range(TEST_LOOP_COUNT):
-	create_delete_volume()
+        create_delete_volume()
 
 def compress_volume(volume_name):
     mountpoint = mount_volume(volume_name)
@@ -678,7 +678,7 @@ def process_restore_with_original_removed(driver, dest = ""):
     if driver == DM:
         #cannot specify different size with backup
         with pytest.raises(subprocess.CalledProcessError):
-	    res_volume1_name = create_volume(VOLUME_SIZE_SMALL, "res-vol1", bak,
+            res_volume1_name = create_volume(VOLUME_SIZE_SMALL, "res-vol1", bak,
                     driver = driver)
 
     res_volume1_name = create_volume(name = "res-vol1", backup = bak, driver =

--- a/vfs/vfs_objectstore.go
+++ b/vfs/vfs_objectstore.go
@@ -36,7 +36,7 @@ func init() {
 	}
 }
 
-func initFunc(destURL string) (objectstore.ObjectStoreDriver, error) {
+func initFunc(destURL, endpoint string) (objectstore.ObjectStoreDriver, error) {
 	b := &VfsObjectStoreDriver{}
 	u, err := url.Parse(destURL)
 	if err != nil {


### PR DESCRIPTION
I've recently come across convoy and I really love it's simplicity! ❤️ 

I've also started using [Minio](https://github.com/minio/minio) for S3 backups, but unfortunately convoy didn't support custom endpoint URLs. This PR adds the ability to change the endpoint to one's own Minio S3 server, or any other.

~This solution uses an awkwardly named environment variable so that will likely need to be implemented differently.~_(fixed)_ Additionally, I couldn't think of a good way to change the current `s3://` URL parsing logic that would be backward-compatible.

I'm open to any suggestions/questions and happy to adapt this to your style 😄 

Edit: Looks like this could resolve https://github.com/rancher/convoy/issues/46